### PR TITLE
Update governance to support token 2022

### DIFF
--- a/governance/chat/program/tests/process_post_message_2022.rs
+++ b/governance/chat/program/tests/process_post_message_2022.rs
@@ -1,0 +1,151 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    program_test::GovernanceChatProgramTest, solana_program_test::tokio,
+    solana_sdk::signature::Keypair, spl_governance::error::GovernanceError,
+    spl_governance_chat::error::GovernanceChatError,
+};
+
+mod program_test;
+
+#[tokio::test]
+async fn test_post_message() {
+    // Arrange
+    let mut governance_chat_test = GovernanceChatProgramTest::start_new_with_token_2022().await;
+
+    let proposal_cookie = governance_chat_test.with_proposal().await;
+
+    // Act
+    let chat_message_cookie = governance_chat_test
+        .with_chat_message(&proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let chat_message_data = governance_chat_test
+        .get_message_account(&chat_message_cookie.address)
+        .await;
+
+    assert_eq!(chat_message_data, chat_message_cookie.account);
+}
+
+#[tokio::test]
+async fn test_post_reply_message() {
+    // Arrange
+    let mut governance_chat_test = GovernanceChatProgramTest::start_new_with_token_2022().await;
+
+    let proposal_cookie = governance_chat_test.with_proposal().await;
+
+    let chat_message_cookie1 = governance_chat_test
+        .with_chat_message(&proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Act
+    let chat_message_cookie2 = governance_chat_test
+        .with_chat_message(&proposal_cookie, Some(chat_message_cookie1.address))
+        .await
+        .unwrap();
+
+    // Assert
+    let chat_message_data = governance_chat_test
+        .get_message_account(&chat_message_cookie2.address)
+        .await;
+
+    assert_eq!(chat_message_data, chat_message_cookie2.account);
+}
+
+#[tokio::test]
+async fn test_post_message_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_chat_test = GovernanceChatProgramTest::start_new_with_token_2022().await;
+
+    let mut proposal_cookie = governance_chat_test.with_proposal().await;
+
+    proposal_cookie.token_owner = Keypair::new();
+
+    // Act
+    let err = governance_chat_test
+        .with_chat_message(&proposal_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_post_message_with_invalid_governance_for_proposal_error() {
+    // Arrange
+    let mut governance_chat_test = GovernanceChatProgramTest::start_new_with_token_2022().await;
+
+    let proposal_cookie1 = governance_chat_test.with_proposal().await;
+
+    let mut proposal_cookie2 = governance_chat_test.with_proposal().await;
+
+    // Try to use proposal from a different realm
+    proposal_cookie2.address = proposal_cookie1.address;
+
+    // Act
+    let err = governance_chat_test
+        .with_chat_message(&proposal_cookie2, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGovernanceForProposal.into());
+}
+
+#[tokio::test]
+async fn test_post_message_with_not_enough_tokens_error() {
+    // Arrange
+    let mut governance_chat_test = GovernanceChatProgramTest::start_new_with_token_2022().await;
+
+    let mut proposal_cookie = governance_chat_test.with_proposal().await;
+
+    let token_owner_record_cookie = governance_chat_test
+        .with_token_owner_deposit(&proposal_cookie, 0)
+        .await;
+
+    proposal_cookie.token_owner_record_address = token_owner_record_cookie.address;
+    proposal_cookie.token_owner = token_owner_record_cookie.token_owner;
+
+    // Act
+    let err = governance_chat_test
+        .with_chat_message(&proposal_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceChatError::NotEnoughTokensToCommentProposal.into()
+    );
+}
+
+#[tokio::test]
+async fn test_post_message_with_voter_weight_addin() {
+    // Arrange
+    let mut governance_chat_test = GovernanceChatProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let proposal_cookie = governance_chat_test.with_proposal().await;
+
+    // Act
+    let chat_message_cookie = governance_chat_test
+        .with_chat_message(&proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let chat_message_data = governance_chat_test
+        .get_message_account(&chat_message_cookie.address)
+        .await;
+
+    assert_eq!(chat_message_data, chat_message_cookie.account);
+}

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -37,23 +37,39 @@ pub struct GovernanceChatProgramTest {
     pub program_id: Pubkey,
     pub governance_program_id: Pubkey,
     pub voter_weight_addin_id: Option<Pubkey>,
+    pub token_program_id: Pubkey
 }
 
 impl GovernanceChatProgramTest {
     #[allow(dead_code)]
     pub async fn start_new() -> Self {
-        Self::start_impl(false).await
+        Self::start_impl(false,false).await
+    }
+    #[allow(dead_code)]
+    pub async fn start_new_with_token_2022() -> Self {
+        Self::start_impl(false,true).await
     }
 
     #[allow(dead_code)]
     pub async fn start_with_voter_weight_addin() -> Self {
         ensure_addin_mock_is_built();
-        Self::start_impl(true).await
+        Self::start_impl(true,false).await
+    }
+    #[allow(dead_code)]
+    pub async fn start_with_voter_weight_addin_with_token_2022() -> Self {
+        ensure_addin_mock_is_built();
+        Self::start_impl(true,true).await
     }
 
     #[allow(dead_code)]
-    async fn start_impl(use_voter_weight_addin: bool) -> Self {
+    async fn start_impl(use_voter_weight_addin: bool,with_token_2022:bool) -> Self {
         let mut program_test = ProgramTest::default();
+
+         //Default that it is normal token
+         let mut token_program_id = spl_token::id();
+         if with_token_2022 {
+             token_program_id = spl_token_2022::id();
+         }
 
         let program_id = Pubkey::from_str("GovernanceChat11111111111111111111111111111").unwrap();
         program_test.add_program(
@@ -86,6 +102,7 @@ impl GovernanceChatProgramTest {
             program_id,
             governance_program_id,
             voter_weight_addin_id,
+            token_program_id
         }
     }
 
@@ -104,6 +121,7 @@ impl GovernanceChatProgramTest {
                 &governing_token_mint_keypair,
                 &governing_token_mint_authority.pubkey(),
                 None,
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -126,6 +144,7 @@ impl GovernanceChatProgramTest {
             name.clone(),
             1,
             MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -149,6 +168,7 @@ impl GovernanceChatProgramTest {
                     amount,
                     &token_owner,
                     &transfer_authority.pubkey(),
+                    Some(&self.token_program_id)
                 )
                 .await;
 
@@ -161,6 +181,7 @@ impl GovernanceChatProgramTest {
                 &self.bench.payer.pubkey(),
                 amount,
                 &governing_token_mint_keypair.pubkey(),
+                Some(&self.token_program_id)
             );
 
             self.bench
@@ -323,6 +344,7 @@ impl GovernanceChatProgramTest {
                 deposit_amount,
                 &token_owner,
                 &transfer_authority.pubkey(),
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -335,6 +357,7 @@ impl GovernanceChatProgramTest {
             &self.bench.payer.pubkey(),
             deposit_amount,
             &proposal_cookie.governing_token_mint,
+            Some(&self.token_program_id)
         );
 
         self.bench

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -23,6 +23,9 @@ solana-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [
+  "no-entrypoint",
+] }
 spl-governance-tools = { version = "0.1.4", path = "../tools" }
 spl-governance-addin-api = { version = "0.1.4", path = "../addin-api" }
 thiserror = "1.0"

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -635,7 +635,16 @@ pub fn create_realm(
     name: String,
     min_community_weight_to_create_governance: u64,
     community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
+    token_program_id:Option<&Pubkey>
 ) -> Instruction {
+    //Determine if token_program_id is provided else set it to normal token program
+    let normal_spl_token = &spl_token::id();
+    let token_program = if token_program_id.is_some() {
+        token_program_id.unwrap()
+    }else{
+        normal_spl_token
+    };
+    
     let realm_address = get_realm_address(program_id, &name);
     let community_token_holding_address =
         get_governing_token_holding_address(program_id, &realm_address, community_token_mint);
@@ -647,7 +656,7 @@ pub fn create_realm(
         AccountMeta::new(community_token_holding_address, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(*token_program, false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
 
@@ -702,7 +711,15 @@ pub fn deposit_governing_tokens(
     // Args
     amount: u64,
     governing_token_mint: &Pubkey,
+    token_program_id:Option<&Pubkey>
 ) -> Instruction {
+    //Determine if token_program_id is provided else set it to normal token program
+    let normal_spl_token = &spl_token::id();
+    let token_program = if token_program_id.is_some() {
+        token_program_id.unwrap()
+    }else{
+        normal_spl_token
+    };
     let token_owner_record_address = get_token_owner_record_address(
         program_id,
         realm,
@@ -724,7 +741,7 @@ pub fn deposit_governing_tokens(
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(*token_program, false),
         AccountMeta::new_readonly(realm_config_address, false),
     ];
 
@@ -746,7 +763,15 @@ pub fn withdraw_governing_tokens(
     governing_token_owner: &Pubkey,
     // Args
     governing_token_mint: &Pubkey,
+    token_program_id:Option<&Pubkey>
 ) -> Instruction {
+    //Determine if token_program_id is provided else set it to normal token program
+    let normal_spl_token = &spl_token::id();
+    let token_program = if token_program_id.is_some() {
+        token_program_id.unwrap()
+    }else{
+        normal_spl_token
+    };
     let token_owner_record_address = get_token_owner_record_address(
         program_id,
         realm,
@@ -765,7 +790,7 @@ pub fn withdraw_governing_tokens(
         AccountMeta::new(*governing_token_destination, false),
         AccountMeta::new_readonly(*governing_token_owner, true),
         AccountMeta::new(token_owner_record_address, false),
-        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(*token_program, false),
         AccountMeta::new_readonly(realm_config_address, false),
     ];
 
@@ -1499,7 +1524,15 @@ pub fn revoke_governing_tokens(
     revoke_authority: &Pubkey,
     // Args
     amount: u64,
+    token_program_id:Option<&Pubkey>
 ) -> Instruction {
+    //Determine if token_program_id is provided else set it to normal token program
+    let normal_spl_token = &spl_token::id();
+    let token_program = if token_program_id.is_some() {
+        token_program_id.unwrap()
+    }else{
+        normal_spl_token
+    };
     let token_owner_record_address = get_token_owner_record_address(
         program_id,
         realm,
@@ -1519,7 +1552,7 @@ pub fn revoke_governing_tokens(
         AccountMeta::new(*governing_token_mint, false),
         AccountMeta::new_readonly(*revoke_authority, true),
         AccountMeta::new_readonly(realm_config_address, false),
-        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(*token_program, false),
     ];
 
     let instruction = GovernanceInstruction::RevokeGoverningTokens { amount };

--- a/governance/program/src/tools/spl_token.rs
+++ b/governance/program/src/tools/spl_token.rs
@@ -18,7 +18,7 @@ use {
     spl_token::{
         instruction::{set_authority, AuthorityType},
         state::{Account, Mint},
-    },
+    }
 };
 
 /// Creates and initializes SPL token account with PDA using the provided PDA
@@ -36,12 +36,23 @@ pub fn create_spl_token_account_signed<'a>(
     rent_sysvar_info: &AccountInfo<'a>,
     rent: &Rent,
 ) -> Result<(), ProgramError> {
+    //Define the spl_token_id to normal token
+    let mut token_program_id = &spl_token::id();
+    let token_2022_pubkey = spl_token_2022::id();
+    //Check if the spl_token_mint owner belongs to normal token or token2022 else give an error
+    if token_mint_info.owner != &spl_token::id() && token_mint_info.owner != &spl_token_2022::id(){
+        return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
+    }
+    //Check if spl_token_mint owner belongs to token 2022 then reassign it to token 2022
+    if token_mint_info.owner == &spl_token_2022::id(){
+        token_program_id = &token_2022_pubkey;
+    }
     let create_account_instruction = system_instruction::create_account(
         payer_info.key,
         token_account_info.key,
         1.max(rent.minimum_balance(spl_token::state::Account::get_packed_len())),
         spl_token::state::Account::get_packed_len() as u64,
-        &spl_token::id(),
+        token_program_id,
     );
 
     let (account_address, bump_seed) =
@@ -71,7 +82,7 @@ pub fn create_spl_token_account_signed<'a>(
     )?;
 
     let initialize_account_instruction = spl_token::instruction::initialize_account(
-        &spl_token::id(),
+        token_program_id,
         token_account_info.key,
         token_mint_info.key,
         token_account_owner_info.key,
@@ -100,8 +111,20 @@ pub fn transfer_spl_tokens<'a>(
     amount: u64,
     spl_token_info: &AccountInfo<'a>,
 ) -> ProgramResult {
+    //Define the spl_token_id to normal token
+    let mut token_program_id = &spl_token::id();
+    let token_2022_pubkey = spl_token_2022::id();
+    //Check if the spl_token_mint owner belongs to normal token or token2022 else give an error
+    if spl_token_info.key != &spl_token::id() && spl_token_info.key != &spl_token_2022::id(){
+        return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
+    }
+    //Check if spl_token_mint owner belongs to token 2022 then reassign it to token 2022
+    if spl_token_info.key == &spl_token_2022::id(){
+        token_program_id = &token_2022_pubkey;
+    }
+
     let transfer_instruction = spl_token::instruction::transfer(
-        &spl_token::id(),
+        token_program_id,
         source_info.key,
         destination_info.key,
         authority_info.key,
@@ -131,8 +154,19 @@ pub fn mint_spl_tokens_to<'a>(
     amount: u64,
     spl_token_info: &AccountInfo<'a>,
 ) -> ProgramResult {
+    //Define the spl_token_id to normal token
+    let mut token_program_id = &spl_token::id();
+    let token_2022_pubkey = spl_token_2022::id();
+    //Check if the spl_token_mint owner belongs to normal token or token2022 else give an error
+    if mint_info.owner != &spl_token::id() && mint_info.owner != &spl_token_2022::id(){
+        return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
+    }
+    //Check if spl_token_mint owner belongs to token 2022 then reassign it to token 2022
+    if mint_info.owner == &spl_token_2022::id(){
+        token_program_id = &token_2022_pubkey;
+    }
     let mint_to_ix = spl_token::instruction::mint_to(
-        &spl_token::id(),
+        token_program_id,
         mint_info.key,
         destination_info.key,
         mint_authority_info.key,
@@ -165,6 +199,18 @@ pub fn transfer_spl_tokens_signed<'a>(
     amount: u64,
     spl_token_info: &AccountInfo<'a>,
 ) -> ProgramResult {
+    //Define the spl_token_id to normal token
+    let mut token_program_id = &spl_token::id();
+    let token_2022_pubkey = spl_token_2022::id();
+    //Check if the spl_token_mint owner belongs to normal token or token2022 else give an error
+    if spl_token_info.key != &spl_token::id() && spl_token_info.key != &spl_token_2022::id(){
+        return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
+    }
+    //Check if spl_token_mint owner belongs to token 2022 then reassign it to token 2022
+    if spl_token_info.key == &spl_token_2022::id(){
+        token_program_id = &token_2022_pubkey;
+    }
+
     let (authority_address, bump_seed) = Pubkey::find_program_address(authority_seeds, program_id);
 
     if authority_address != *authority_info.key {
@@ -177,7 +223,7 @@ pub fn transfer_spl_tokens_signed<'a>(
     }
 
     let transfer_instruction = spl_token::instruction::transfer(
-        &spl_token::id(),
+        token_program_id,
         source_info.key,
         destination_info.key,
         authority_info.key,
@@ -215,6 +261,17 @@ pub fn burn_spl_tokens_signed<'a>(
     amount: u64,
     spl_token_info: &AccountInfo<'a>,
 ) -> ProgramResult {
+    //Define the spl_token_id to normal token
+    let mut token_program_id = &spl_token::id();
+    let token_2022_pubkey = spl_token_2022::id();
+    //Check if the spl_token_mint owner belongs to normal token or token2022 else give an error
+    if token_mint_info.owner != &spl_token::id() && token_mint_info.owner != &spl_token_2022::id(){
+        return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
+    }
+    //Check if spl_token_mint owner belongs to token 2022 then reassign it to token 2022
+    if token_mint_info.owner == &spl_token_2022::id(){
+        token_program_id = &token_2022_pubkey;
+    }
     let (authority_address, bump_seed) = Pubkey::find_program_address(authority_seeds, program_id);
 
     if authority_address != *authority_info.key {
@@ -227,7 +284,7 @@ pub fn burn_spl_tokens_signed<'a>(
     }
 
     let burn_ix = spl_token::instruction::burn(
-        &spl_token::id(),
+        token_program_id,
         token_account_info.key,
         token_mint_info.key,
         authority_info.key,
@@ -261,7 +318,7 @@ pub fn assert_is_valid_spl_token_account(account_info: &AccountInfo) -> Result<(
         return Err(GovernanceError::SplTokenAccountDoesNotExist.into());
     }
 
-    if account_info.owner != &spl_token::id() {
+    if account_info.owner != &spl_token::id() && account_info.owner != &spl_token_2022::id() {
         return Err(GovernanceError::SplTokenAccountWithInvalidOwner.into());
     }
 
@@ -298,7 +355,7 @@ pub fn assert_is_valid_spl_token_mint(mint_info: &AccountInfo) -> Result<(), Pro
         return Err(GovernanceError::SplTokenMintDoesNotExist.into());
     }
 
-    if mint_info.owner != &spl_token::id() {
+    if mint_info.owner != &spl_token::id() && mint_info.owner != &spl_token_2022::id() {
         return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
     }
 
@@ -419,8 +476,19 @@ pub fn set_spl_token_account_authority<'a>(
     authority_type: AuthorityType,
     spl_token_info: &AccountInfo<'a>,
 ) -> Result<(), ProgramError> {
+    //Define the spl_token_id to normal token
+    let mut token_program_id = &spl_token::id();
+    let token_2022_pubkey = spl_token_2022::id();
+    //Check if the spl_token_mint owner belongs to normal token or token2022 else give an error
+    if spl_token_info.key != &spl_token::id() && spl_token_info.key != &spl_token_2022::id(){
+        return Err(GovernanceError::SplTokenMintWithInvalidOwner.into());
+    }
+    //Check if spl_token_mint owner belongs to token 2022 then reassign it to token 2022
+    if spl_token_info.key == &spl_token_2022::id(){ 
+        token_program_id = &token_2022_pubkey;
+    }
     let set_authority_ix = set_authority(
-        &spl_token::id(),
+        token_program_id,
         account_info.key,
         Some(new_account_authority),
         authority_type,

--- a/governance/program/tests/migrate_legacy_accounts_2022.rs
+++ b/governance/program/tests/migrate_legacy_accounts_2022.rs
@@ -1,0 +1,82 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use {
+    program_test::{legacy::*, *},
+    spl_governance::state::{
+        enums::{VoteThreshold, VoteTipping},
+        governance::DEFAULT_DEPOSIT_EXEMPT_PROPOSAL_COUNT,
+    },
+};
+
+#[tokio::test]
+async fn test_create_proposal_and_migrate_governance_v1_to_v2() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Override Governance account with LegacyV1 version
+    let mut governance_v1: LegacyGovernanceV1 = governance_cookie.account.clone().into();
+    governance_v1.config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(55);
+
+    governance_test.set_account(&governance_cookie.address, &governance_v1);
+
+    // Act
+    governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(1, governance_account.active_proposal_count);
+
+    assert_eq!(
+        VoteThreshold::YesVotePercentage(55),
+        governance_account.config.council_vote_threshold
+    );
+
+    assert_eq!(
+        VoteThreshold::YesVotePercentage(55),
+        governance_account.config.council_veto_vote_threshold
+    );
+
+    assert_eq!(
+        VoteThreshold::Disabled,
+        governance_account.config.community_veto_vote_threshold
+    );
+
+    assert_eq!(
+        DEFAULT_DEPOSIT_EXEMPT_PROPOSAL_COUNT,
+        governance_account.config.deposit_exempt_proposal_count
+    );
+
+    assert_eq!(0, governance_account.reserved1);
+
+    assert_eq!(
+        VoteTipping::Strict,
+        governance_account.config.council_vote_tipping
+    );
+
+    assert_eq!(
+        VoteTipping::Strict,
+        governance_account.config.community_vote_tipping
+    );
+}

--- a/governance/program/tests/process_add_required_signatory_2022.rs
+++ b/governance/program/tests/process_add_required_signatory_2022.rs
@@ -1,0 +1,188 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    num_traits::cast::ToPrimitive,
+    program_test::*,
+    solana_program::{
+        program_error::ProgramError, pubkey::Pubkey, system_instruction::SystemError,
+    },
+    solana_program_test::tokio,
+    solana_sdk::signature::Signer,
+    spl_governance::{error::GovernanceError, instruction::add_required_signatory},
+};
+
+#[tokio::test]
+async fn test_add_required_signatory() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory = Pubkey::new_unique();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(1, governance_account.required_signatories_count);
+}
+
+#[tokio::test]
+pub async fn add_same_required_signatory_to_governance_twice_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let (token_owner_record_cookie, mut governance_cookie, realm_cookie, signatory) =
+        governance_test
+            .with_governance_with_required_signatory()
+            .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &proposal_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        ProgramError::Custom(SystemError::AccountAlreadyInUse.to_u32().unwrap())
+    );
+}
+
+#[tokio::test]
+pub async fn add_required_signatory_to_governance_without_governance_signer_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory = Pubkey::new_unique();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut gwr_ix = add_required_signatory(
+        &governance_test.program_id,
+        &governance_cookie.address,
+        &governance_test.bench.payer.pubkey(),
+        &signatory,
+    );
+
+    gwr_ix.accounts[0].is_signer = false;
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[gwr_ix], Some(&[]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::GovernancePdaMustSign.into());
+}

--- a/governance/program/tests/process_add_signatory_2022.rs
+++ b/governance/program/tests/process_add_signatory_2022.rs
@@ -1,0 +1,451 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program::program_error::ProgramError,
+    solana_program_test::tokio,
+    solana_sdk::{pubkey::Pubkey, signature::Signer},
+    spl_governance::{
+        error::GovernanceError,
+        instruction::{add_signatory, AddSignatoryAuthority, GovernanceInstruction},
+    },
+};
+
+#[tokio::test]
+async fn test_add_signatory() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let signatory_record_account = governance_test
+        .get_signatory_record_account(&signatory_record_cookie.address)
+        .await;
+
+    assert_eq!(signatory_record_cookie.account, signatory_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(1, proposal_account.signatories_count);
+}
+
+#[tokio::test]
+async fn test_add_signatory_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let other_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.token_owner = other_token_owner_record_cookie.token_owner;
+
+    // Act
+    let err = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_add_signatory_with_invalid_proposal_owner_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let other_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.address = other_token_owner_record_cookie.address;
+
+    // Act
+    let err = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidProposalOwnerAccount.into());
+}
+
+#[tokio::test]
+async fn test_add_signatory_for_required_signatory() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory = Pubkey::new_unique();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    let new_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let new_signatory_record_cookie = governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let signatory_account = governance_test
+        .get_signatory_record_account(&new_signatory_record_cookie.address)
+        .await;
+
+    assert_eq!(signatory_account.signatory, signatory);
+    assert_eq!(signatory_account.proposal, new_proposal_cookie.address);
+    assert!(!signatory_account.signed_off);
+
+    let new_proposal_account = governance_test
+        .get_proposal_account(&new_proposal_cookie.address)
+        .await;
+
+    assert_eq!(new_proposal_account.signatories_count, 1);
+}
+
+#[tokio::test]
+async fn test_add_signatory_for_required_signatory_multiple_times_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory = Pubkey::new_unique();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    let new_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::SignatoryRecordAlreadyExists.into());
+}
+
+#[tokio::test]
+pub async fn test_add_optional_signatory_before_all_required_signatories_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let (token_owner_record_cookie, mut governance_cookie, _, _) = governance_test
+        .with_governance_with_required_signatory()
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, ProgramError::UninitializedAccount);
+}
+
+#[tokio::test]
+pub async fn test_add_optional_signatory_to_proposal_with_required_signatories() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let (token_owner_record_cookie, mut governance_cookie, _, signatory) = governance_test
+        .with_governance_with_required_signatory()
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(proposal_account.signatories_count, 2);
+}
+
+#[tokio::test]
+pub async fn test_add_non_matching_required_signatory_to_proposal_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let (token_owner_record_cookie, mut governance_cookie, _, signatory) = governance_test
+        .with_governance_with_required_signatory()
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let mut create_signatory_record_ix = add_signatory(
+        &governance_test.program_id,
+        &governance_cookie.address,
+        &proposal_cookie.address,
+        &AddSignatoryAuthority::None,
+        &governance_test.bench.payer.pubkey(),
+        &signatory.pubkey(),
+    );
+
+    create_signatory_record_ix.data = borsh::to_vec(&GovernanceInstruction::AddSignatory {
+        signatory: Pubkey::new_unique(),
+    })
+    .unwrap();
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[create_signatory_record_ix], Some(&[]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidSignatoryAddress.into());
+}

--- a/governance/program/tests/process_cancel_proposal_2022.rs
+++ b/governance/program/tests/process_cancel_proposal_2022.rs
@@ -1,0 +1,289 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+};
+
+#[tokio::test]
+async fn test_cancel_proposal() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Cancelled, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
+
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record_account.outstanding_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.active_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cancel_proposal_with_already_completed_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotCancelProposal.into()
+    );
+}
+
+#[tokio::test]
+async fn test_cancel_proposal_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.token_owner = token_owner_record_cookie2.token_owner;
+
+    // Act
+    let err = governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_cancel_proposal_with_vote_time_expired_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    // Act
+
+    let err = governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::ProposalVotingTimeExpired.into());
+}
+
+#[tokio::test]
+async fn test_cancel_proposal_after_voting_cool_off_with_vote_time_expired_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Set none default voting cool off time
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.voting_cool_off_time = 10;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            (governance_cookie.account.config.voting_base_time
+                + governance_cookie.account.config.voting_cool_off_time) as i64
+                + clock.unix_timestamp,
+        )
+        .await;
+
+    // Act
+
+    let err = governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::ProposalVotingTimeExpired.into());
+}
+
+#[tokio::test]
+async fn test_cancel_proposal_in_voting_state() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Cancelled, proposal_account.state);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.active_proposal_count);
+}

--- a/governance/program/tests/process_cast_vote_2022.rs
+++ b/governance/program/tests/process_cast_vote_2022.rs
@@ -1,0 +1,1509 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::{MintMaxVoterWeightSource, ProposalState, VoteThreshold, VoteTipping},
+            vote_record::Vote,
+        },
+    },
+};
+
+#[tokio::test]
+async fn test_cast_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.options[0].vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    assert_eq!(
+        proposal_account.voting_completed_at,
+        Some(clock.unix_timestamp)
+    );
+
+    assert_eq!(Some(100), proposal_account.max_vote_weight);
+    assert_eq!(
+        Some(governance_cookie.account.config.community_vote_threshold),
+        proposal_account.vote_threshold
+    );
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record.unrelinquished_votes_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.active_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_invalid_governance_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Setup another Governance
+    let governance_cookie2 = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    proposal_cookie.account.governance = governance_cookie2.address;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidGovernanceForProposal.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_invalid_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to use Council Mint with Community Proposal
+    token_owner_record_cookie.account.governing_token_mint =
+        realm_cookie.account.config.council_mint.unwrap();
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidGoverningMintForProposal.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_invalid_token_owner_record_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to use token_owner_record for Council Mint with Community Proposal
+    let token_owner_record_cookie2 = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.address = token_owner_record_cookie2.address;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningMintForTokenOwnerRecord.into()
+    );
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_invalid_token_owner_record_from_different_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to use token_owner_record from another Realm for the same mint
+    let realm_cookie2 = governance_test.with_realm_using_mints(&realm_cookie).await;
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie2)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.address = token_owner_record_cookie2.address;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidRealmForTokenOwnerRecord.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_governance_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to use a different owner to sign
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.token_owner = token_owner_record_cookie2.token_owner;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_strict_vote_tipped_to_succeeded() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_strict_vote_tipped_to_defeated() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 votes
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    // 100 votes
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 votes
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Total 320 votes
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Early;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(15);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie4 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie5 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 500) // total supply: 1000
+        .await;
+
+    // Test: tip by reaching 200 yes, 100 deny
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+
+    // Test: 200 vs 200 is above 15% yes, but does not tip yet
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie4,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act: 300 vs 200 makes it tip
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie5,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.active_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Early;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
+
+    // 100 votes
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // 100 votes
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 votes
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Total 320 votes
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Total 210 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 110)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(1, proposal_owner_record.outstanding_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(1, governance_account.active_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_yes_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20) // total supply: 120
+        .await;
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act: no deny tipping
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_no_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20) // total supply: 120
+        .await;
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_voting_time_expired_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let vote_expired_at = proposal_account.voting_at.unwrap()
+        + governance_cookie.account.config.voting_base_time as i64;
+
+    governance_test
+        .advance_clock_past_timestamp(vote_expired_at)
+        .await;
+
+    // Act
+
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::ProposalVotingTimeExpired.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_cast_twice_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::VoteAlreadyExists.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_invalid_proposal_owner_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to use an invalid account as the proposal owner
+    proposal_cookie.account.token_owner_record = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidProposalOwnerAccount.into());
+}
+
+#[tokio::test]
+async fn test_cast_tipping_vote_with_invalid_proposal_owner_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Create another voter and vote
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Try to use the other voter as the proposal owner
+    proposal_cookie.account.token_owner_record = token_owner_record_cookie2.address;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidProposalOwnerAccount.into());
+}
+
+#[tokio::test]
+async fn test_cast_council_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+
+    assert_eq!(
+        Some(governance_cookie.account.config.council_vote_threshold),
+        proposal_account.vote_threshold
+    );
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_invalid_realm_config_account_address_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try bypass config check by using none existing config account
+    let realm_config_address = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .with_cast_vote_using_instruction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            Vote::Deny,
+            |i| {
+                i.accounts[10].pubkey = realm_config_address; // realm_config_address
+            },
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmConfigAddress.into());
+}
+
+#[tokio::test]
+async fn test_cast_early_council_vote_with_disabled_community_vote_tipping() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.council_vote_tipping = VoteTipping::Early;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+}
+
+#[tokio::test]
+async fn test_cast_community_vote_with_early_council_and_disabled_community_vote_tipping() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.council_vote_tipping = VoteTipping::Early;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_and_max_yes_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_and_max_no_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    // Reduce max voter weight to 50% for the cast vote to be above max_voter_weight
+    let realm_config_args = RealmSetupArgs {
+        community_mint_max_voter_weight_source: MintMaxVoterWeightSource::SupplyFraction(
+            MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
+        ),
+        ..Default::default()
+    };
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let governance_config = governance_test.get_default_governance_config();
+
+    // Mint and deposit 100 tokens to Member
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint 20 community tokens to increase total supply to 120
+    // It gives us max_voter_weight==60 which is below the cast vote weight of 100
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    // max_vote_weight should be coerced from 60 to 100
+    assert_eq!(proposal_account.max_vote_weight, Some(100))
+}
+
+#[tokio::test]
+async fn test_cast_approve_vote_with_cannot_vote_in_cool_off_time_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Set none default voting cool off time
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.voting_cool_off_time = 50;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Advance timestamp into voting_cool_off_time
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .advance_clock_past_timestamp(
+            clock.unix_timestamp + governance_cookie.account.config.voting_base_time as i64,
+        )
+        .await;
+
+    // Act
+
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::VoteNotAllowedInCoolOffTime.into());
+}

--- a/governance/program/tests/process_complete_proposal_2022.rs
+++ b/governance/program/tests/process_complete_proposal_2022.rs
@@ -1,0 +1,217 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+};
+
+#[tokio::test]
+async fn test_complete_proposal() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Ensure
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    // Act
+    governance_test
+        .complete_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
+}
+
+#[tokio::test]
+async fn test_complete_proposal_with_wrong_state_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Ensure
+    let proposal = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Draft, proposal.state);
+
+    // Act
+    let err = governance_test
+        .complete_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidStateToCompleteProposal.into());
+}
+
+#[tokio::test]
+async fn test_complete_proposal_with_completed_state_transaction_exists_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_token_account_cookie = governance_test
+        .with_governed_token_account(&governance_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_transfer_tokens_transaction(
+            &governed_token_account_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // transaction exists while not advancing the time
+
+    let proposal = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Succeeded, proposal.state);
+    assert!(!proposal_transaction_cookie.account.instructions.is_empty());
+
+    // Act
+    let err = governance_test
+        .complete_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(err, GovernanceError::InvalidStateToCompleteProposal.into());
+}
+
+#[tokio::test]
+async fn test_complete_proposal_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Try to maliciously sign using different owner signature
+    let token_owner_record_cookie2 = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    token_owner_record_cookie.token_owner = token_owner_record_cookie2.token_owner;
+
+    // Act
+    let err = governance_test
+        .complete_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}

--- a/governance/program/tests/process_create_governance_2022.rs
+++ b/governance/program/tests/process_create_governance_2022.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "test-sbf")]
+mod program_test;
+
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_program_test::*,
+    solana_sdk::signature::Keypair,
+    spl_governance::{error::GovernanceError, state::enums::VoteThreshold},
+    spl_governance_tools::error::GovernanceToolsError,
+};
+
+#[tokio::test]
+async fn test_create_governance() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}
+
+#[tokio::test]
+async fn test_create_governance_with_invalid_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    realm_cookie.address = governance_cookie.address;
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceToolsError::InvalidAccountType.into());
+}
+
+#[tokio::test]
+async fn test_create_governance_with_invalid_config_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Arrange
+    let mut config = governance_test.get_default_governance_config();
+    config.community_vote_threshold = VoteThreshold::YesVotePercentage(0); // below 1% threshold
+
+    // Act
+    let err = governance_test
+        .with_governance_using_config(&realm_cookie, &token_owner_record_cookie, &config)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidVoteThresholdPercentage.into());
+
+    // Arrange
+    let mut config = governance_test.get_default_governance_config();
+    config.community_vote_threshold = VoteThreshold::YesVotePercentage(101); // Above 100% threshold
+
+    // Act
+    let err = governance_test
+        .with_governance_using_config(&realm_cookie, &token_owner_record_cookie, &config)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidVoteThresholdPercentage.into());
+}
+
+#[tokio::test]
+async fn test_create_governance_with_not_enough_community_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Set token deposit amount below the required threshold
+    let token_amount = 4;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit_amount(&realm_cookie, token_amount)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::NotEnoughTokensToCreateGovernance.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_governance_with_not_enough_council_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Set token deposit amount below the required threshold
+    let token_amount: u64 = 0;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit_amount(&realm_cookie, token_amount)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::NotEnoughTokensToCreateGovernance.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_governance_using_realm_authority() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let config = governance_test.get_default_governance_config();
+    let realm_authority = realm_cookie.realm_authority.as_ref().unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance_impl(&realm_cookie, None, realm_authority, None, &config, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}
+
+#[tokio::test]
+async fn test_create_governance_using_realm_authority_with_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let config = governance_test.get_default_governance_config();
+    let realm_authority = realm_cookie.realm_authority.as_ref().unwrap();
+
+    // Act
+    let err = governance_test
+        .with_governance_impl(
+            &realm_cookie,
+            None,
+            realm_authority,
+            None,
+            &config,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_create_governance_using_realm_authority_with_wrong_authority_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let config = governance_test.get_default_governance_config();
+    let authority = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .with_governance_impl(
+            &realm_cookie,
+            Some(&token_owner_record_cookie.address),
+            &authority,
+            None,
+            &config,
+            Some(&[&authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_governance_with_community_disabled_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_config_args = RealmSetupArgs {
+        min_community_weight_to_create_governance: u64::MAX,
+        ..Default::default()
+    };
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    // Set token deposit amount to max
+    let token_amount = u64::MAX;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit_amount(&realm_cookie, token_amount)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::VoterWeightThresholdDisabled.into());
+}

--- a/governance/program/tests/process_create_native_treasury_2022.rs
+++ b/governance/program/tests/process_create_native_treasury_2022.rs
@@ -1,0 +1,123 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+
+#[tokio::test]
+async fn test_create_native_treasury() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let native_treasury_cookie = governance_test
+        .with_native_treasury(&governance_cookie)
+        .await;
+
+    // Assert
+
+    let native_treasury_account = governance_test
+        .get_native_treasury_account(&native_treasury_cookie.address)
+        .await;
+
+    assert_eq!(native_treasury_cookie.account, native_treasury_account);
+}
+
+#[tokio::test]
+async fn test_execute_transfer_from_native_treasury() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_native_treasury(&governance_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let wallet_cookie = governance_test.bench.with_wallet().await;
+    let transfer_amount = 100;
+
+    let proposal_transaction_cookie = governance_test
+        .with_native_transfer_transaction(
+            &governance_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &wallet_cookie,
+            transfer_amount,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let wallet_account = governance_test
+        .bench
+        .get_account(&wallet_cookie.address)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        wallet_account.lamports,
+        wallet_cookie.account.lamports + transfer_amount
+    )
+}

--- a/governance/program/tests/process_create_proposal_2022.rs
+++ b/governance/program/tests/process_create_proposal_2022.rs
@@ -1,0 +1,718 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_program_test::*,
+};
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_sdk::signature::Keypair,
+    spl_governance::{
+        error::GovernanceError,
+        state::{enums::VoteThreshold, governance::SECURITY_DEPOSIT_BASE_LAMPORTS},
+    },
+    spl_governance_tools::account::AccountMaxSize,
+};
+
+#[tokio::test]
+async fn test_create_community_proposal() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record_account.outstanding_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(1, governance_account.active_proposal_count);
+}
+
+#[tokio::test]
+async fn test_create_multiple_proposals() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let community_token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &community_token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let community_proposal_cookie = governance_test
+        .with_proposal(&community_token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let council_proposal_cookie = governance_test
+        .with_proposal(&council_token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let community_proposal_account = governance_test
+        .get_proposal_account(&community_proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        community_proposal_cookie.account,
+        community_proposal_account
+    );
+
+    let council_proposal_account = governance_test
+        .get_proposal_account(&council_proposal_cookie.address)
+        .await;
+
+    assert_eq!(council_proposal_cookie.account, council_proposal_account);
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_not_authorized_governance_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.governance_authority = Some(Keypair::new());
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_governance_delegate_signer() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_community_governance_delegate(&realm_cookie, &mut token_owner_record_cookie)
+        .await;
+
+    token_owner_record_cookie.governance_authority =
+        Some(token_owner_record_cookie.clone_governance_delegate());
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_not_enough_community_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    // Set token deposit amount below the required threshold
+    let token_amount = 4;
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit_amount(&realm_cookie, token_amount)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie2, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::NotEnoughTokensToCreateProposal.into());
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_not_enough_council_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Set token deposit amount below the required threshold
+    let token_amount = 1;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit_amount(&realm_cookie, token_amount)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::NotEnoughTokensToCreateProposal.into());
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_proposal_using_instruction(&token_owner_record_cookie, &mut governance_cookie, |i| {
+            // Set token_owner_record_address for different (Council) mint
+            i.accounts[3] =
+                AccountMeta::new_readonly(council_token_owner_record_cookie.address, false);
+        })
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_invalid_governing_token_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Try to use mint which  doesn't belong to the Realm
+    token_owner_record_cookie.account.governing_token_mint = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGoverningTokenMint.into());
+}
+
+#[tokio::test]
+async fn test_create_community_proposal_using_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut community_token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &community_token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Change the proposal owner to council token owner
+    community_token_owner_record_cookie.address = council_token_owner_record_cookie.address;
+    community_token_owner_record_cookie.token_owner = council_token_owner_record_cookie.token_owner;
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(&community_token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        realm_cookie.account.community_mint,
+        proposal_account.governing_token_mint
+    );
+
+    assert_eq!(
+        council_token_owner_record_cookie.address,
+        proposal_account.token_owner_record
+    );
+}
+
+#[tokio::test]
+async fn test_create_council_proposal_using_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &council_token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let community_token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Change the proposal owner to community token owner
+    council_token_owner_record_cookie.address = community_token_owner_record_cookie.address;
+    council_token_owner_record_cookie.token_owner = community_token_owner_record_cookie.token_owner;
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(&council_token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        realm_cookie.account.config.council_mint.unwrap(),
+        proposal_account.governing_token_mint
+    );
+
+    assert_eq!(
+        community_token_owner_record_cookie.address,
+        proposal_account.token_owner_record
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_disabled_council_vote_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.council_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenMintNotAllowedToVote.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_disabled_community_vote_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenMintNotAllowedToVote.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_invalid_realm_config_account_address_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Try bypass config check by using none existing config account
+    let realm_config_address = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .with_proposal_using_instruction(&token_owner_record_cookie, &mut governance_cookie, |i| {
+            i.accounts[8].pubkey = realm_config_address;
+        })
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmConfigAddress.into());
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_community_disabled_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Set token deposit amount to max
+    let token_amount = u64::MAX;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit_amount(&realm_cookie, token_amount)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.min_community_weight_to_create_proposal = u64::MAX;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::VoterWeightThresholdDisabled.into());
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_security_deposit() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    // Deposit is taken for every Proposal
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_deposit_account = governance_test
+        .get_proposal_deposit_account(&proposal_cookie.proposal_deposit.address)
+        .await;
+
+    assert_eq!(
+        proposal_cookie.proposal_deposit.account,
+        proposal_deposit_account
+    );
+
+    let proposal_deposit_account_info = governance_test
+        .bench
+        .get_account(&proposal_cookie.proposal_deposit.address)
+        .await
+        .unwrap();
+
+    let expected_lamports = governance_test
+        .bench
+        .rent
+        .minimum_balance(proposal_deposit_account.get_max_size().unwrap())
+        + SECURITY_DEPOSIT_BASE_LAMPORTS;
+
+    assert_eq!(expected_lamports, proposal_deposit_account_info.lamports);
+}
+
+#[tokio::test]
+async fn test_create_multiple_proposals_with_security_deposits() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    // Make the fist Proposal deposit free and take the deposit for Proposal 2 & 3
+    governance_config.deposit_exempt_proposal_count = 1;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let proposal_cookie1 = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie2 = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie3 = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_deposit_account_info1 = governance_test
+        .bench
+        .get_account(&proposal_cookie1.proposal_deposit.address)
+        .await;
+
+    assert_eq!(None, proposal_deposit_account_info1);
+
+    // Proposal 2
+    let proposal_deposit_account2 = governance_test
+        .get_proposal_deposit_account(&proposal_cookie2.proposal_deposit.address)
+        .await;
+
+    assert_eq!(
+        proposal_cookie2.proposal_deposit.account,
+        proposal_deposit_account2
+    );
+
+    let proposal_deposit_account_info2 = governance_test
+        .bench
+        .get_account(&proposal_cookie2.proposal_deposit.address)
+        .await
+        .unwrap();
+
+    let expected_lamports = governance_test
+        .bench
+        .rent
+        .minimum_balance(proposal_deposit_account2.get_max_size().unwrap())
+        + SECURITY_DEPOSIT_BASE_LAMPORTS;
+
+    assert_eq!(expected_lamports, proposal_deposit_account_info2.lamports);
+
+    // Proposal 3
+    let proposal_deposit_account3 = governance_test
+        .get_proposal_deposit_account(&proposal_cookie3.proposal_deposit.address)
+        .await;
+
+    assert_eq!(
+        proposal_cookie3.proposal_deposit.account,
+        proposal_deposit_account3
+    );
+
+    let proposal_deposit_account_info3 = governance_test
+        .bench
+        .get_account(&proposal_cookie3.proposal_deposit.address)
+        .await
+        .unwrap();
+
+    let expected_lamports = governance_test
+        .bench
+        .rent
+        .minimum_balance(proposal_deposit_account3.get_max_size().unwrap())
+        + 2 * SECURITY_DEPOSIT_BASE_LAMPORTS;
+
+    assert_eq!(expected_lamports, proposal_deposit_account_info3.lamports);
+}

--- a/governance/program/tests/process_create_realm_2022.rs
+++ b/governance/program/tests/process_create_realm_2022.rs
@@ -13,7 +13,7 @@ use {
 #[tokio::test]
 async fn test_create_realm() {
     // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
 
     // Act
     let realm_cookie = governance_test.with_realm().await;
@@ -27,10 +27,11 @@ async fn test_create_realm() {
 }
 
 
+
 #[tokio::test]
 async fn test_create_realm_with_non_default_config() {
     // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
 
     let realm_setup_args = RealmSetupArgs {
         use_council_mint: false,
@@ -57,7 +58,7 @@ async fn test_create_realm_with_non_default_config() {
 #[tokio::test]
 async fn test_create_realm_with_max_voter_weight_absolute_value() {
     // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
 
     let realm_setup_args = RealmSetupArgs {
         community_mint_max_voter_weight_source: MintMaxVoterWeightSource::Absolute(1),
@@ -84,11 +85,10 @@ async fn test_create_realm_with_max_voter_weight_absolute_value() {
     );
 }
 
-
 #[tokio::test]
 async fn test_create_realm_for_existing_pda() {
     // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
 
     let realm_name = format!("Realm #{}", governance_test.next_realm_id).to_string();
     let realm_address = get_realm_address(&governance_test.program_id, &realm_name);

--- a/governance/program/tests/process_create_token_owner_record_2022.rs
+++ b/governance/program/tests/process_create_token_owner_record_2022.rs
@@ -11,7 +11,7 @@ use {
 #[tokio::test]
 async fn test_create_token_owner_record() {
     // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
     let realm_cookie = governance_test.with_realm().await;
 
     // Act

--- a/governance/program/tests/process_deposit_governing_tokens_2022.rs
+++ b/governance/program/tests/process_deposit_governing_tokens_2022.rs
@@ -1,0 +1,366 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::instruction::AccountMeta, solana_program_test::*};
+
+mod program_test;
+
+use {
+    crate::program_test::args::*,
+    program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{
+        error::GovernanceError,
+        instruction::deposit_governing_tokens,
+        state::{
+            realm_config::GoverningTokenType, token_owner_record::TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+        },
+    },
+};
+
+#[tokio::test]
+async fn test_deposit_initial_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record_cookie.account, token_owner_record);
+
+    assert_eq!(
+        TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+        token_owner_record.version
+    );
+    assert_eq!(0, token_owner_record.unrelinquished_votes_count);
+
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount
+            - token_owner_record_cookie
+                .account
+                .governing_token_deposit_amount,
+        source_account.amount
+    );
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
+
+    assert_eq!(
+        token_owner_record.governing_token_deposit_amount,
+        holding_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_deposit_initial_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let council_token_holding_account = realm_cookie.council_token_holding_account.unwrap();
+
+    // Act
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record_cookie.account, token_owner_record);
+
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount
+            - token_owner_record_cookie
+                .account
+                .governing_token_deposit_amount,
+        source_account.amount
+    );
+
+    let holding_account = governance_test
+        .get_token_account(&council_token_holding_account)
+        .await;
+
+    assert_eq!(
+        token_owner_record.governing_token_deposit_amount,
+        holding_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_deposit_subsequent_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let deposit_amount = 5;
+    let total_deposit_amount = token_owner_record_cookie
+        .account
+        .governing_token_deposit_amount
+        + deposit_amount;
+
+    governance_test.advance_clock().await;
+
+    // Act
+    governance_test
+        .with_subsequent_community_token_deposit(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            deposit_amount,
+        )
+        .await;
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(
+        total_deposit_amount,
+        token_owner_record.governing_token_deposit_amount
+    );
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
+
+    assert_eq!(total_deposit_amount, holding_account.amount);
+}
+
+#[tokio::test]
+async fn test_deposit_subsequent_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let council_token_holding_account = realm_cookie.council_token_holding_account.unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let deposit_amount = 5;
+    let total_deposit_amount = token_owner_record_cookie
+        .account
+        .governing_token_deposit_amount
+        + deposit_amount;
+
+    governance_test.advance_clock().await;
+
+    // Act
+    governance_test
+        .with_subsequent_council_token_deposit(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            deposit_amount,
+        )
+        .await;
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(
+        total_deposit_amount,
+        token_owner_record.governing_token_deposit_amount
+    );
+
+    let holding_account = governance_test
+        .get_token_account(&council_token_holding_account)
+        .await;
+
+    assert_eq!(total_deposit_amount, holding_account.amount);
+}
+
+#[tokio::test]
+async fn test_deposit_initial_community_tokens_with_owner_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner = Keypair::new();
+    let transfer_authority = Keypair::new();
+    let token_source = Keypair::new();
+
+    let amount = 10;
+
+    governance_test
+        .bench
+        .create_token_account_with_transfer_authority(
+            &token_source,
+            &realm_cookie.account.community_mint,
+            &realm_cookie.community_mint_authority,
+            amount,
+            &token_owner,
+            &transfer_authority.pubkey(),
+        )
+        .await;
+
+    let mut deposit_ix = deposit_governing_tokens(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &token_source.pubkey(),
+        &token_owner.pubkey(),
+        &transfer_authority.pubkey(),
+        &governance_test.bench.context.payer.pubkey(),
+        amount,
+        &realm_cookie.account.community_mint,
+    );
+
+    deposit_ix.accounts[3] = AccountMeta::new_readonly(token_owner.pubkey(), false);
+
+    // Act
+
+    let error = governance_test
+        .bench
+        .process_transaction(&[deposit_ix], Some(&[&transfer_authority]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(error, GovernanceError::GoverningTokenOwnerMustSign.into());
+}
+
+#[tokio::test]
+async fn test_deposit_community_tokens_with_malicious_holding_account_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let amount = 50;
+
+    governance_test
+        .bench
+        .mint_tokens(
+            &realm_cookie.account.community_mint,
+            &realm_cookie.community_mint_authority,
+            &token_owner_record_cookie.token_source,
+            amount,
+        )
+        .await;
+
+    let mut deposit_ix = deposit_governing_tokens(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &token_owner_record_cookie.token_source,
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &governance_test.bench.context.payer.pubkey(),
+        amount,
+        &realm_cookie.account.community_mint,
+    );
+
+    // Try to maliciously deposit to the source
+    deposit_ix.accounts[1].pubkey = token_owner_record_cookie.token_source;
+
+    // Act
+
+    let err = governance_test
+        .bench
+        .process_transaction(
+            &[deposit_ix],
+            Some(&[&token_owner_record_cookie.token_owner]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningTokenHoldingAccount.into()
+    );
+}
+
+#[tokio::test]
+async fn test_deposit_community_tokens_using_mint() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    let token_owner_record_cookie = governance_test
+        .with_initial_governing_token_deposit_using_mint(
+            &realm_cookie.address,
+            &realm_cookie.account.community_mint,
+            &realm_cookie.community_mint_authority,
+            10,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record_cookie.account, token_owner_record);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
+
+    assert_eq!(
+        token_owner_record.governing_token_deposit_amount,
+        holding_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_deposit_comunity_tokens_with_cannot_deposit_dormant_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Dormant;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    // Act
+    let err = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::CannotDepositDormantTokens.into());
+}

--- a/governance/program/tests/process_execute_transaction_2022.rs
+++ b/governance/program/tests/process_execute_transaction_2022.rs
@@ -1,0 +1,779 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        sysvar::clock,
+    },
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::enums::{ProposalState, TransactionExecutionStatus},
+    },
+};
+
+#[tokio::test]
+async fn test_execute_mint_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(1, yes_option.transactions_executed_count);
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);
+
+    let proposal_transaction_account = governance_test
+        .get_proposal_transaction_account(&proposal_transaction_cookie.address)
+        .await;
+
+    assert_eq!(
+        Some(clock.unix_timestamp),
+        proposal_transaction_account.executed_at
+    );
+
+    assert_eq!(
+        TransactionExecutionStatus::Success,
+        proposal_transaction_account.execution_status
+    );
+
+    let instruction_token_account = governance_test
+        .get_token_account(&proposal_transaction_cookie.account.instructions[0].accounts[1].pubkey)
+        .await;
+
+    assert_eq!(10, instruction_token_account.amount);
+}
+
+#[tokio::test]
+async fn test_execute_transfer_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_token_account_cookie = governance_test
+        .with_governed_token_account(&governance_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_transfer_tokens_transaction(
+            &governed_token_account_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(1, yes_option.transactions_executed_count);
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);
+
+    let proposal_transaction_account = governance_test
+        .get_proposal_transaction_account(&proposal_transaction_cookie.address)
+        .await;
+
+    assert_eq!(
+        Some(clock.unix_timestamp),
+        proposal_transaction_account.executed_at
+    );
+
+    assert_eq!(
+        TransactionExecutionStatus::Success,
+        proposal_transaction_account.execution_status
+    );
+
+    let instruction_token_account = governance_test
+        .get_token_account(&proposal_transaction_cookie.account.instructions[0].accounts[1].pubkey)
+        .await;
+
+    assert_eq!(15, instruction_token_account.amount);
+}
+
+// Ignored until program-test manages fork graphs correctly, see
+// https://github.com/solana-labs/solana/pull/34407 for the failing downstream
+// test
+#[tokio::test]
+#[ignore]
+async fn test_execute_upgrade_program_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_program_cookie = governance_test
+        .with_governed_program(&governance_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_upgrade_program_transaction(
+            &governance_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Ensure we can invoke the governed program before upgrade
+    let governed_program_ix = Instruction::new_with_bytes(
+        governed_program_cookie.address,
+        &[0],
+        vec![AccountMeta::new(clock::id(), false)],
+    );
+
+    let err = governance_test
+        .bench
+        .process_transaction(&[governed_program_ix.clone()], None)
+        .await
+        .err()
+        .unwrap();
+
+    // solana_bpf_rust_upgradable returns CustomError == 42
+    assert_eq!(ProgramError::Custom(42), err);
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(1, yes_option.transactions_executed_count);
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);
+
+    let proposal_transaction_account = governance_test
+        .get_proposal_transaction_account(&proposal_transaction_cookie.address)
+        .await;
+
+    assert_eq!(
+        Some(clock.unix_timestamp),
+        proposal_transaction_account.executed_at
+    );
+
+    assert_eq!(
+        TransactionExecutionStatus::Success,
+        proposal_transaction_account.execution_status
+    );
+
+    // Assert we can invoke the governed program after upgrade
+
+    governance_test.advance_clock().await;
+
+    let err = governance_test
+        .bench
+        .process_transaction(&[governed_program_ix.clone()], None)
+        .await
+        .err()
+        .unwrap();
+
+    // solana_bpf_rust_upgraded returns CustomError == 43
+    assert_eq!(ProgramError::Custom(43), err);
+
+    // --------------------------- !!! Voila  !!! -----------------------------
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_execute_proposal_transaction_with_invalid_state_errors() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie1 = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie2 = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+
+    // Arrange
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie1)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+
+    // Arrange
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie2)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+
+    // Arrange
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::CannotExecuteTransactionWithinHoldUpTime.into()
+    );
+
+    // Arrange
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    // Arrange
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_execute_proposal_transaction_for_other_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance clock past hold_up_time
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie2 = governance_test
+        .with_proposal(&token_owner_record_cookie2, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie2, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidProposalForProposalTransaction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_execute_mint_transaction_twice_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance clock past hold_up_time
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::TransactionAlreadyExecuted.into());
+}
+
+#[tokio::test]
+async fn test_execute_transaction_with_create_proposal_and_execute_in_single_slot_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.transactions_hold_up_time = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::CannotExecuteTransactionWithinHoldUpTime.into()
+    );
+}

--- a/governance/program/tests/process_finalize_vote_2022.rs
+++ b/governance/program/tests/process_finalize_vote_2022.rs
@@ -1,0 +1,479 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::enums::{ProposalState, VoteThreshold},
+    },
+};
+
+#[tokio::test]
+async fn test_finalize_vote_to_succeeded() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Total 210 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 110)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Ensure not tipped
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64
+                + proposal_account.voting_at.unwrap(),
+        )
+        .await;
+
+    // Act
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    assert_eq!(
+        Some(proposal_account.voting_max_time_end(&governance_cookie.account.config)),
+        proposal_account.voting_completed_at
+    );
+
+    assert_eq!(Some(210), proposal_account.max_vote_weight);
+
+    assert_eq!(
+        Some(governance_cookie.account.config.community_vote_threshold),
+        proposal_account.vote_threshold
+    );
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.active_proposal_count);
+}
+
+#[tokio::test]
+async fn test_finalize_vote_to_defeated() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Ensure not tipped
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Advance clock past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64
+                + proposal_account.voting_at.unwrap(),
+        )
+        .await;
+
+    // Act
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_invalid_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Ensure not tipped
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    proposal_cookie.account.governing_token_mint =
+        realm_cookie.account.config.council_mint.unwrap();
+
+    // Act
+
+    let err = governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidGoverningMintForProposal.into());
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_invalid_governance_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Ensure not tipped
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Setup another Governance
+
+    let governance_cookie2 = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    proposal_cookie.account.governance = governance_cookie2.address;
+
+    // Act
+
+    let err = governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidGovernanceForProposal.into());
+}
+
+#[tokio::test]
+async fn test_finalize_council_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.council_vote_threshold = VoteThreshold::YesVotePercentage(40);
+    governance_config.community_vote_threshold = VoteThreshold::Disabled;
+
+    // Deposit 100 council tokens
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Total 210 council tokens in circulation
+    governance_test
+        .mint_council_tokens(&realm_cookie, 110)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Cast vote with 47% weight, above 40% quorum but below 50%+1 to tip
+    // automatically
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Ensure not tipped
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64
+                + proposal_account.voting_at.unwrap(),
+        )
+        .await;
+
+    // Act
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    assert_eq!(
+        Some(proposal_account.voting_max_time_end(&governance_cookie.account.config)),
+        proposal_account.voting_completed_at
+    );
+
+    assert_eq!(Some(210), proposal_account.max_vote_weight);
+
+    assert_eq!(
+        Some(governance_cookie.account.config.council_vote_threshold),
+        proposal_account.vote_threshold
+    );
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_cannot_finalize_during_voting_time_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 210 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 110)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+
+    let err = governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotFinalizeVotingInProgress.into());
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_cannot_finalize_during_cool_off_time_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Set none default voting cool off time
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.voting_cool_off_time = 50;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Total 210 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 110)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp into voting_cool_off_time
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .advance_clock_past_timestamp(
+            clock.unix_timestamp + governance_cookie.account.config.voting_base_time as i64,
+        )
+        .await;
+
+    // Act
+
+    let err = governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotFinalizeVotingInProgress.into());
+}

--- a/governance/program/tests/process_insert_transaction_2022.rs
+++ b/governance/program/tests/process_insert_transaction_2022.rs
@@ -1,0 +1,302 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {program_test::*, solana_program_test::tokio, spl_governance::error::GovernanceError};
+
+#[tokio::test]
+async fn test_insert_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let proposal_transaction_cookie = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_transaction_account = governance_test
+        .get_proposal_transaction_account(&proposal_transaction_cookie.address)
+        .await;
+
+    assert_eq!(
+        proposal_transaction_cookie.account,
+        proposal_transaction_account
+    );
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.transactions_count, 1);
+    assert_eq!(yes_option.transactions_next_index, 1);
+    assert_eq!(yes_option.transactions_executed_count, 0);
+}
+
+#[tokio::test]
+async fn test_insert_multiple_transactions() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.transactions_count, 2);
+    assert_eq!(yes_option.transactions_next_index, 2);
+    assert_eq!(yes_option.transactions_executed_count, 0);
+}
+
+#[tokio::test]
+async fn test_insert_transaction_with_invalid_index_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(1))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidTransactionIndex.into());
+}
+
+#[tokio::test]
+async fn test_insert_transaction_with_proposal_transaction_already_exists_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(0))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::TransactionAlreadyExists.into());
+}
+
+#[tokio::test]
+async fn test_insert_transaction_with_not_editable_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotEditTransactions.into()
+    );
+}
+
+#[tokio::test]
+async fn test_insert_transaction_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.token_owner = token_owner_record_cookie2.token_owner;
+
+    // Act
+    let err = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_insert_transaction_with_invalid_governance_for_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to maliciously use a different governance account to use with the
+    // proposal
+
+    let governance_cookie2 = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    proposal_cookie.account.governance = governance_cookie2.address;
+
+    let new_governance_config = governance_test.get_default_governance_config();
+
+    // Act
+    let err = governance_test
+        .with_set_governance_config_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &new_governance_config,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGovernanceForProposal.into());
+}

--- a/governance/program/tests/process_refund_proposal_deposit_2022.rs
+++ b/governance/program/tests/process_refund_proposal_deposit_2022.rs
@@ -1,0 +1,313 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::program_error::ProgramError, solana_program_test::*};
+
+mod program_test;
+
+use {program_test::*, spl_governance::error::GovernanceError};
+
+#[tokio::test]
+async fn test_refund_proposal_deposit() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .refund_proposal_deposit(&proposal_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_deposit_account_info = governance_test
+        .bench
+        .get_account(&proposal_cookie.proposal_deposit.address)
+        .await;
+
+    assert_eq!(None, proposal_deposit_account_info);
+}
+
+#[tokio::test]
+async fn test_refund_proposal_deposit_with_cannot_refund_draft_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .refund_proposal_deposit(&proposal_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRefundProposalDeposit.into());
+}
+
+#[tokio::test]
+async fn test_refund_proposal_deposit_with_cannot_refund_voting_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .refund_proposal_deposit(&proposal_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRefundProposalDeposit.into());
+}
+
+#[tokio::test]
+async fn test_refund_proposal_deposit_with_invalid_proposal_deposit_payer_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Try to refund the deposit to account which is different than Proposal deposit
+    // payer
+    let deposit_payer2 = governance_test.bench.with_wallet().await;
+
+    // Act
+    let err = governance_test
+        .refund_proposal_deposit_using_instruction(
+            &proposal_cookie,
+            |i| {
+                i.accounts[2].pubkey = deposit_payer2.address; // proposal_deposit_payer
+            },
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidDepositPayerForProposalDeposit.into()
+    );
+}
+
+#[tokio::test]
+async fn test_refund_proposal_deposit_with_invalid_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Try to refund deposit from a different proposal
+    let proposal_cookie2 = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .refund_proposal_deposit_using_instruction(
+            &proposal_cookie,
+            |i| {
+                i.accounts[1].pubkey = proposal_cookie2.proposal_deposit.address;
+                // proposal_deposit
+            },
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidProposalForProposalDeposit.into()
+    );
+}
+
+#[tokio::test]
+async fn test_refund_proposal_deposit_with_invalid_proposal_deposit_account_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.deposit_exempt_proposal_count = 0;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .refund_proposal_deposit_using_instruction(
+            &proposal_cookie,
+            |i| {
+                // Try to drain the Proposal account
+                i.accounts[1].pubkey = proposal_cookie.address;
+            },
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, ProgramError::UninitializedAccount);
+}

--- a/governance/program/tests/process_relinquish_token_owner_record_locks_2022.rs
+++ b/governance/program/tests/process_relinquish_token_owner_record_locks_2022.rs
@@ -1,0 +1,527 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    solana_sdk::{program_error::ProgramError, signature::Keypair, signer::Signer},
+    spl_governance::{
+        error::GovernanceError, state::realm::SetRealmConfigItemArgs,
+        tools::structs::SetConfigItemActionType,
+    },
+};
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_lock() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie.authority),
+            Some(vec![token_owner_record_lock_cookie.lock_id]),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record_account.locks.len());
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_with_invalid_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority),
+            Some(vec![token_owner_record_lock_cookie.lock_id]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::TokenOwnerRecordLockNotFound.into());
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_with_missing_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            None,
+            Some(vec![token_owner_record_lock_cookie.lock_id]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, ProgramError::NotEnoughAccountKeys);
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_with_invalid_lock_id_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie.authority),
+            Some(vec![0]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::TokenOwnerRecordLockNotFound.into());
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_with_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .relinquish_token_owner_record_locks_using_ix(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie.authority),
+            Some(vec![token_owner_record_lock_cookie.lock_id]),
+            |i| i.accounts[3].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::TokenOwnerRecordLockAuthorityMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_after_authority_revoked() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Revoke authority
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Remove,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: token_owner_record_lock_authority_cookie.authority.pubkey(),
+    };
+
+    governance_test
+        .set_realm_config_item(&realm_cookie, args)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie.authority),
+            Some(vec![token_owner_record_lock_cookie.lock_id]),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record_account.locks.len());
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_after_authority_revoked_and_without_signature() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Revoke authority
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Remove,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: token_owner_record_lock_authority_cookie.authority.pubkey(),
+    };
+
+    governance_test
+        .set_realm_config_item(&realm_cookie, args)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_token_owner_record_locks_using_ix(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie.authority),
+            Some(vec![token_owner_record_lock_cookie.lock_id]),
+            |i| i.accounts[3].is_signer = false, // Remove authority signature
+            Some(&[]),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record_account.locks.len());
+}
+
+#[tokio::test]
+async fn test_relinquish_expired_token_owner_record_lock() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Set none expiring lock
+
+    let lock_id = 100;
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Set another lock
+    let token_owner_record_lock_authority_cookie2 = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie2 = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie2,
+        )
+        .await
+        .unwrap();
+
+    // And expire it
+    governance_test
+        .advance_clock_past_timestamp(token_owner_record_lock_cookie2.expiry.unwrap())
+        .await;
+
+    // Act
+    governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie2.authority),
+            Some(vec![token_owner_record_lock_cookie2.lock_id]),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record_account.locks.len());
+    assert_eq!(lock_id, token_owner_record_account.locks[0].lock_id);
+}
+
+#[tokio::test]
+async fn test_relinquish_token_owner_record_locks_for_expired_locks_only() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Set none expiring lock
+
+    let lock_id = 100;
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Set another lock
+    let token_owner_record_lock_authority_cookie2 = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie2 = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie2,
+        )
+        .await
+        .unwrap();
+
+    // And expire it
+    governance_test
+        .advance_clock_past_timestamp(token_owner_record_lock_cookie2.expiry.unwrap())
+        .await;
+
+    // Act
+    governance_test
+        .relinquish_token_owner_record_locks(&token_owner_record_cookie, None, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record_account.locks.len());
+    assert_eq!(lock_id, token_owner_record_account.locks[0].lock_id);
+}
+
+#[tokio::test]
+async fn test_relinquish_multiple_token_owner_record_locks() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let lock_type1 = 1;
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_type1,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let lock_type2 = 2;
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_type2,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_token_owner_record_locks(
+            &token_owner_record_cookie,
+            Some(&token_owner_record_lock_authority_cookie.authority),
+            Some(vec![lock_type1, lock_type2]),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record_account.locks.len());
+}

--- a/governance/program/tests/process_relinquish_vote_2022.rs
+++ b/governance/program/tests/process_relinquish_vote_2022.rs
@@ -1,0 +1,627 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_program_test::tokio,
+    solana_sdk::signer::Signer,
+    spl_governance::{
+        error::GovernanceError,
+        instruction::{cast_vote, relinquish_vote},
+        state::{
+            enums::{ProposalState, VoteTipping},
+            vote_record::{Vote, VoteChoice},
+        },
+    },
+};
+
+#[tokio::test]
+async fn test_relinquish_voted_proposal() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let mut vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(100, proposal_account.options[0].vote_weight);
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.unrelinquished_votes_count);
+
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    vote_record_cookie.account.is_relinquished = true;
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+}
+
+#[tokio::test]
+async fn test_relinquish_active_yes_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(0, proposal_account.deny_vote_weight.unwrap());
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.unrelinquished_votes_count);
+
+    let vote_record_account = governance_test
+        .bench
+        .get_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(None, vote_record_account);
+}
+
+#[tokio::test]
+async fn test_relinquish_active_no_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(0, proposal_account.deny_vote_weight.unwrap());
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.unrelinquished_votes_count);
+
+    let vote_record_account = governance_test
+        .bench
+        .get_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(None, vote_record_account);
+}
+
+#[tokio::test]
+async fn test_relinquish_vote_with_invalid_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.account.governing_token_mint = Pubkey::new_unique();
+
+    // Act
+
+    let err = governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidGoverningTokenMint.into());
+}
+
+#[tokio::test]
+async fn test_relinquish_vote_with_governance_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Try to use a different owner to sign
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.token_owner = token_owner_record_cookie2.token_owner;
+
+    // Act
+
+    let err = governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_relinquish_vote_with_invalid_vote_record_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Total 400 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    let vote_record_cookie2 = governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // // Act
+
+    let err = governance_test
+        .relinquish_vote_using_instruction(&proposal_cookie, &token_owner_record_cookie, |i| {
+            i.accounts[4] = AccountMeta::new(vote_record_cookie2.address, false)
+            // Try to use a vote_record for other token owner
+        })
+        .await
+        .err()
+        .unwrap();
+
+    // // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningTokenOwnerForVoteRecord.into()
+    );
+}
+
+#[tokio::test]
+async fn test_relinquish_vote_with_already_relinquished_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Ensure vote is relinquished
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert!(vote_record_account.is_relinquished);
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 10)
+        .await;
+
+    governance_test.advance_clock().await;
+    // Act
+
+    let err = governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::VoteAlreadyRelinquished.into());
+}
+
+#[tokio::test]
+async fn test_relinquish_proposal_with_cannot_relinquish_in_finalizing_state_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Deposit 100 tokens
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Add 200 tokens (total 300) to prevent the vote being tipped
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    // Act
+    let err = governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::CannotRelinquishInFinalizingState.into()
+    );
+}
+
+#[tokio::test]
+async fn test_relinquish_and_cast_vote_in_single_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    let relinquish_vote_ix = relinquish_vote(
+        &governance_test.program_id,
+        &token_owner_record_cookie.account.realm,
+        &proposal_cookie.account.governance,
+        &proposal_cookie.address,
+        &token_owner_record_cookie.address,
+        &token_owner_record_cookie.account.governing_token_mint,
+        Some(token_owner_record_cookie.token_owner.pubkey()),
+        Some(governance_test.bench.payer.pubkey()),
+    );
+
+    let cast_vote_ix = cast_vote(
+        &governance_test.program_id,
+        &token_owner_record_cookie.account.realm,
+        &proposal_cookie.account.governance,
+        &proposal_cookie.address,
+        &proposal_cookie.account.token_owner_record,
+        &token_owner_record_cookie.address,
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &token_owner_record_cookie.account.governing_token_mint,
+        &governance_test.bench.payer.pubkey(),
+        None,
+        None,
+        Vote::Approve(vec![VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        }]),
+    );
+
+    // Act
+    governance_test
+        .bench
+        .process_transaction(
+            &[relinquish_vote_ix, cast_vote_ix],
+            Some(&[&token_owner_record_cookie.token_owner]),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+}
+
+#[tokio::test]
+async fn test_change_yes_vote_to_no_within_cool_off_time() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Set none default voting cool off time
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.voting_cool_off_time = 50;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Total 300 tokens
+    governance_test
+        .mint_community_tokens(&realm_cookie, 200)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp into voting_cool_off_time
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .advance_clock_past_timestamp(
+            clock.unix_timestamp + governance_cookie.account.config.voting_base_time as i64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(100, proposal_account.deny_vote_weight.unwrap());
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}

--- a/governance/program/tests/process_remove_required_signatory_2022.rs
+++ b/governance/program/tests/process_remove_required_signatory_2022.rs
@@ -1,0 +1,205 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    solana_sdk::signature::Signer,
+    spl_governance::{error::GovernanceError, instruction::remove_required_signatory},
+    spl_governance_tools::error::GovernanceToolsError,
+};
+
+#[tokio::test]
+async fn test_remove_required_signatory() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let (token_owner_record_cookie, mut governance_cookie, realm_cookie, signatory) =
+        governance_test
+            .with_governance_with_required_signatory()
+            .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let beneficiary = Pubkey::new_unique();
+
+    let proposal_transaction_cookie = governance_test
+        .with_remove_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+            &beneficiary,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &proposal_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let after_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&after_proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.signatories_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.required_signatories_count);
+}
+
+#[tokio::test]
+async fn test_remove_non_existing_required_signatory_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let (token_owner_record_cookie, mut governance_cookie, realm_cookie, signatory) =
+        governance_test
+            .with_governance_with_required_signatory()
+            .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let beneficiary = Pubkey::new_unique();
+
+    let proposal_transaction_cookie = governance_test
+        .with_remove_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &Pubkey::new_unique(),
+            &beneficiary,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &proposal_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+pub async fn remove_required_signatory_from_governance_without_governance_signer_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory = Pubkey::new_unique();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut gwr_ix = remove_required_signatory(
+        &governance_test.program_id,
+        &governance_cookie.address,
+        &signatory,
+        &governance_test.bench.payer.pubkey(),
+    );
+
+    gwr_ix.accounts[0].is_signer = false;
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[gwr_ix], Some(&[]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::GovernancePdaMustSign.into());
+}

--- a/governance/program/tests/process_remove_transaction_2022.rs
+++ b/governance/program/tests/process_remove_transaction_2022.rs
@@ -1,0 +1,354 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {program_test::*, solana_program_test::tokio, spl_governance::error::GovernanceError};
+
+#[tokio::test]
+async fn test_remove_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    // Act
+
+    governance_test
+        .remove_transaction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_transaction_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.transactions_count, 0);
+    assert_eq!(yes_option.transactions_next_index, 1);
+    assert_eq!(yes_option.transactions_executed_count, 0);
+
+    let proposal_transaction_account = governance_test
+        .bench
+        .get_account(&proposal_transaction_cookie.address)
+        .await;
+
+    assert_eq!(None, proposal_transaction_account);
+}
+
+#[tokio::test]
+async fn test_replace_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    // Act
+
+    governance_test
+        .remove_transaction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_transaction_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie2 = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(0))
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.transactions_count, 2);
+    assert_eq!(yes_option.transactions_next_index, 2);
+
+    let proposal_transaction_account2 = governance_test
+        .get_proposal_transaction_account(&proposal_transaction_cookie2.address)
+        .await;
+
+    assert_eq!(
+        proposal_transaction_cookie2.account,
+        proposal_transaction_account2
+    );
+}
+
+#[tokio::test]
+async fn test_remove_front_transaction() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    // Act
+
+    governance_test
+        .remove_transaction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_transaction_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.transactions_count, 1);
+    assert_eq!(yes_option.transactions_next_index, 2);
+
+    let proposal_transaction_account = governance_test
+        .bench
+        .get_account(&proposal_transaction_cookie.address)
+        .await;
+
+    assert_eq!(None, proposal_transaction_account);
+}
+
+#[tokio::test]
+async fn test_remove_transaction_with_owner_or_delegate_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    token_owner_record_cookie.token_owner = token_owner_record_cookie2.token_owner;
+
+    // Act
+    let err = governance_test
+        .remove_transaction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_transaction_cookie,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_remove_transaction_with_proposal_not_editable_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .remove_transaction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_transaction_cookie,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotEditTransactions.into()
+    );
+}
+
+#[tokio::test]
+async fn test_remove_transaction_with_proposal_transaction_from_other_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie2 = governance_test
+        .with_proposal(&token_owner_record_cookie2, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie2 = governance_test
+        .with_nop_transaction(&mut proposal_cookie2, &token_owner_record_cookie2, 0, None)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .remove_transaction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_transaction_cookie2,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidProposalForProposalTransaction.into()
+    );
+}

--- a/governance/program/tests/process_revoke_governing_tokens_2022.rs
+++ b/governance/program/tests/process_revoke_governing_tokens_2022.rs
@@ -1,0 +1,650 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
+
+mod program_test;
+
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{
+        error::GovernanceError,
+        state::{realm::get_governing_token_holding_address, realm_config::GoverningTokenType},
+    },
+    spl_governance_test_sdk::tools::{clone_keypair, NopOverride},
+};
+
+#[tokio::test]
+async fn test_revoke_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.community_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 0);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
+
+    assert_eq!(holding_account.amount, 0);
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_council_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 0);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.council_token_holding_account.unwrap())
+        .await;
+
+    assert_eq!(holding_account.amount, 0);
+}
+
+#[tokio::test]
+async fn test_revoke_own_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            &token_owner_record_cookie.token_owner,
+            token_owner_record_cookie
+                .account
+                .governing_token_deposit_amount,
+            NopOverride,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 0);
+}
+
+#[tokio::test]
+async fn test_revoke_own_council_tokens_with_owner_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            &token_owner_record_cookie.token_owner,
+            token_owner_record_cookie
+                .account
+                .governing_token_deposit_amount,
+            |i| i.accounts[4].is_signer = false, // revoke_authority
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::GoverningTokenOwnerMustSign.into());
+}
+
+#[tokio::test]
+async fn test_revoke_community_tokens_with_cannot_revoke_liquid_token_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRevokeGoverningTokens.into());
+}
+
+#[tokio::test]
+async fn test_revoke_community_tokens_with_cannot_revoke_dormant_token_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.community_token_config_args.token_type = GoverningTokenType::Dormant;
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_config_args)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRevokeGoverningTokens.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_mint_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| i.accounts[4].is_signer = false, // mint_authority
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::MintAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_invalid_revoke_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            &Keypair::new(), // Try to use fake authority
+            1,
+            NopOverride,
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidMintAuthority.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_invalid_token_holding_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to revoke from the community holding account
+    let governing_token_holding_address = get_governing_token_holding_address(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &realm_cookie.account.community_mint,
+    );
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| i.accounts[1].pubkey = governing_token_holding_address, // governing_token_holding_address
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningTokenHoldingAccount.into()
+    );
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_other_realm_config_account_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try use other Realm config
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| i.accounts[5].pubkey = realm_cookie2.realm_config.address, //realm_config_address
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidRealmConfigForRealm.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_invalid_realm_config_account_address_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try bypass config check by using none existing config account
+    let realm_config_address = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| i.accounts[5].pubkey = realm_config_address, // realm_config_address
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidRealmConfigAddress.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_token_owner_record_for_different_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to revoke from the community token owner record
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| i.accounts[2].pubkey = token_owner_record_cookie2.address, // token_owner_record_address
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningMintForTokenOwnerRecord.into()
+    );
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_too_large_amount_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            200,
+            NopOverride,
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidRevokeAmount.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_partial_revoke_amount() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            5,
+            NopOverride,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 95);
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_community_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to use mint and authority for Community to revoke Council token
+    let governing_token_mint = realm_cookie.account.community_mint;
+    let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
+    let governing_token_holding_address = get_governing_token_holding_address(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &governing_token_mint,
+    );
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| {
+                i.accounts[1].pubkey = governing_token_holding_address;
+                i.accounts[3].pubkey = governing_token_mint;
+                i.accounts[4].pubkey = governing_token_mint_authority.pubkey();
+            }, // mint_authority
+            Some(&[&governing_token_mint_authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRevokeGoverningTokens.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_not_matching_mint_and_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to use a valid mint and authority not matching the Council mint
+    let governing_token_mint = realm_cookie.account.community_mint;
+    let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            1,
+            |i| {
+                i.accounts[3].pubkey = governing_token_mint;
+                i.accounts[4].pubkey = governing_token_mint_authority.pubkey();
+            }, // mint_authority
+            Some(&[&governing_token_mint_authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningTokenHoldingAccount.into()
+    );
+}

--- a/governance/program/tests/process_set_governance_config_2022.rs
+++ b/governance/program/tests/process_set_governance_config_2022.rs
@@ -1,0 +1,238 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::{
+        error::GovernanceError, instruction::set_governance_config, state::enums::VoteThreshold,
+    },
+    spl_governance_test_sdk::tools::ProgramInstructionError,
+    spl_governance_tools::error::GovernanceToolsError,
+};
+
+#[tokio::test]
+async fn test_set_governance_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let mut new_governance_config = governance_test.get_default_governance_config();
+
+    // Change vote_threshold_percentage on the new Governance config
+    new_governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
+
+    let proposal_transaction_cookie = governance_test
+        .with_set_governance_config_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &new_governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(new_governance_config, governance_account.config);
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_governance_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let new_governance_config = governance_test.get_default_governance_config();
+
+    let mut set_governance_config_ix = set_governance_config(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        new_governance_config.clone(),
+    );
+
+    // Remove governance signer from instruction
+    set_governance_config_ix.accounts[0].is_signer = false;
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[set_governance_config_ix], None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::GovernancePdaMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_fake_governance_signer_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let new_governance_config = governance_test.get_default_governance_config();
+
+    let mut set_governance_config_ix = set_governance_config(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        new_governance_config.clone(),
+    );
+
+    // Set Governance signer to fake account we have authority over and can use to
+    // sign the transaction
+    let governance_signer = Keypair::new();
+    set_governance_config_ix.accounts[0].pubkey = governance_signer.pubkey();
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[set_governance_config_ix], Some(&[&governance_signer]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_invalid_governance_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Try to maliciously use a different governance account to change the given
+    // governance config
+
+    let governance_cookie2 = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let new_governance_config = governance_test.get_default_governance_config();
+
+    let mut set_governance_config_ix = set_governance_config(
+        &governance_test.program_id,
+        &governance_cookie2.address,
+        new_governance_config,
+    );
+
+    let proposal_transaction_cookie = governance_test
+        .with_proposal_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+            &mut set_governance_config_ix,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, ProgramInstructionError::PrivilegeEscalation.into());
+}

--- a/governance/program/tests/process_set_governance_delegate_2022.rs
+++ b/governance/program/tests/process_set_governance_delegate_2022.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::instruction::AccountMeta, solana_program_test::*};
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{error::GovernanceError, instruction::set_governance_delegate},
+};
+
+#[tokio::test]
+async fn test_set_community_governance_delegate() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_community_governance_delegate(&realm_cookie, &mut token_owner_record_cookie)
+        .await;
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(
+        Some(token_owner_record_cookie.governance_delegate.pubkey()),
+        token_owner_record.governance_delegate
+    );
+}
+
+#[tokio::test]
+async fn test_set_governance_delegate_to_none() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_community_governance_delegate(&realm_cookie, &mut token_owner_record_cookie)
+        .await;
+
+    // Act
+    governance_test
+        .set_governance_delegate(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &token_owner_record_cookie.token_owner,
+            &realm_cookie.account.community_mint,
+            &None,
+        )
+        .await;
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(None, token_owner_record.governance_delegate);
+}
+
+#[tokio::test]
+async fn test_set_council_governance_delegate() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_council_governance_delegate(&realm_cookie, &mut token_owner_record_cookie)
+        .await;
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(
+        Some(token_owner_record_cookie.governance_delegate.pubkey()),
+        token_owner_record.governance_delegate
+    );
+}
+
+#[tokio::test]
+async fn test_set_community_governance_delegate_with_owner_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let hacker_governance_delegate = Keypair::new();
+
+    let mut set_delegate_ix = set_governance_delegate(
+        &governance_test.program_id,
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &realm_cookie.address,
+        &realm_cookie.account.community_mint,
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &Some(hacker_governance_delegate.pubkey()),
+    );
+
+    set_delegate_ix.accounts[0] =
+        AccountMeta::new_readonly(token_owner_record_cookie.token_owner.pubkey(), false);
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[set_delegate_ix], None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_community_governance_delegate_signed_by_governance_delegate() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_community_governance_delegate(&realm_cookie, &mut token_owner_record_cookie)
+        .await;
+
+    let new_governance_delegate = Keypair::new();
+
+    // Act
+    governance_test
+        .set_governance_delegate(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &token_owner_record_cookie.governance_delegate,
+            &realm_cookie.account.community_mint,
+            &Some(new_governance_delegate.pubkey()),
+        )
+        .await;
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(
+        Some(new_governance_delegate.pubkey()),
+        token_owner_record.governance_delegate
+    );
+}

--- a/governance/program/tests/process_set_realm_authority_2022.rs
+++ b/governance/program/tests/process_set_realm_authority_2022.rs
@@ -1,0 +1,215 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
+
+mod program_test;
+
+use {
+    program_test::*, spl_governance::error::GovernanceError,
+    spl_governance_tools::error::GovernanceToolsError,
+};
+
+#[tokio::test]
+async fn test_set_realm_authority() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let new_realm_authority = governance_cookie.address;
+
+    // Act
+    governance_test
+        .set_realm_authority(&realm_cookie, Some(&new_realm_authority))
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_account.authority, Some(new_realm_authority));
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_non_existing_new_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let new_realm_authority = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .set_realm_authority(&realm_cookie, Some(&new_realm_authority))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_to_none() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    governance_test
+        .set_realm_authority(&realm_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_account.authority, None);
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_unchecked() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let new_realm_authority = Pubkey::new_unique();
+
+    // Act
+    governance_test
+        .set_realm_authority_impl(&realm_cookie, Some(&new_realm_authority), false)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_account.authority, Some(new_realm_authority));
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_no_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    governance_test
+        .set_realm_authority(&realm_cookie, None)
+        .await
+        .unwrap();
+
+    let new_realm_authority = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .set_realm_authority(&realm_cookie, Some(&new_realm_authority))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmHasNoAuthority.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_invalid_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    let new_realm_authority = Pubkey::new_unique();
+
+    // Try to use authority from other realm
+    realm_cookie.realm_authority = realm_cookie2.realm_authority;
+
+    // Act
+    let err = governance_test
+        .set_realm_authority(&realm_cookie, Some(&new_realm_authority))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidAuthorityForRealm.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let new_realm_authority = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .set_realm_authority_using_instruction(
+            &realm_cookie,
+            Some(&new_realm_authority),
+            true,
+            |i| i.accounts[1].is_signer = false, // realm_authority
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_governance_from_other_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Setup other realm
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie2)
+        .await
+        .unwrap();
+
+    let governance_cookie2 = governance_test
+        .with_governance(&realm_cookie2, &token_owner_record_cookie2)
+        .await
+        .unwrap();
+
+    let new_realm_authority = governance_cookie2.address;
+
+    // Act
+    let err = governance_test
+        .set_realm_authority(&realm_cookie, Some(&new_realm_authority))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmForGovernance.into());
+}

--- a/governance/program/tests/process_set_realm_config_2022.rs
+++ b/governance/program/tests/process_set_realm_config_2022.rs
@@ -1,0 +1,414 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*, solana_sdk::signer::Signer};
+
+mod program_test;
+
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    spl_governance::{
+        error::GovernanceError,
+        state::{realm::GoverningTokenConfigAccountArgs, realm_config::GoverningTokenType},
+    },
+};
+
+#[tokio::test]
+async fn test_set_realm_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Act
+
+    let err = governance_test
+        .set_realm_config_using_instruction(
+            &mut realm_cookie,
+            &realm_setup_args,
+            |i| i.accounts[1].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_no_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    governance_test
+        .set_realm_authority(&realm_cookie, None)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .set_realm_config_using_instruction(
+            &mut realm_cookie,
+            &realm_setup_args,
+            |i| i.accounts[1].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmHasNoAuthority.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_invalid_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    // Try to use authority from other realm
+    realm_cookie.realm_authority = realm_cookie2.realm_authority;
+
+    // Act
+
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidAuthorityForRealm.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_remove_council() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
+
+    // Act
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+    assert_eq!(None, realm_account.config.council_mint);
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_council_change_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Try to replace council mint
+    realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
+
+    // Act
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::RealmCouncilMintChangeIsNotSupported.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_council_restore_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Try to restore council mint after removing it
+    realm_setup_args.use_council_mint = true;
+    realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
+
+    // Act
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::RealmCouncilMintChangeIsNotSupported.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_liquid_community_token_cannot_be_changed_to_memebership_error()
+{
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    // Try to change Community token type to Membership
+    realm_setup_args.community_token_config_args.token_type = GoverningTokenType::Membership;
+
+    // Act
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::CannotChangeCommunityTokenTypeToMembership.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_for_community_token_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    // Change Community token type to Dormant and set plugins
+    let realm_setup_args = RealmSetupArgs {
+        community_token_config_args: GoverningTokenConfigAccountArgs {
+            voter_weight_addin: Some(Pubkey::new_unique()),
+            max_voter_weight_addin: Some(Pubkey::new_unique()),
+            token_type: GoverningTokenType::Dormant,
+        },
+        ..Default::default()
+    };
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        realm_config_account.community_token_config.token_type,
+        GoverningTokenType::Dormant
+    );
+
+    assert_eq!(
+        realm_config_account
+            .community_token_config
+            .voter_weight_addin,
+        realm_setup_args
+            .community_token_config_args
+            .voter_weight_addin
+    );
+
+    assert_eq!(
+        realm_config_account
+            .community_token_config
+            .max_voter_weight_addin,
+        realm_setup_args
+            .community_token_config_args
+            .max_voter_weight_addin
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_for_council_token_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    // Change Council token type to Membership and set plugins
+    let realm_setup_args = RealmSetupArgs {
+        council_token_config_args: GoverningTokenConfigAccountArgs {
+            voter_weight_addin: Some(Pubkey::new_unique()),
+            max_voter_weight_addin: Some(Pubkey::new_unique()),
+            token_type: GoverningTokenType::Membership,
+        },
+        ..Default::default()
+    };
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        realm_config_account.council_token_config.token_type,
+        GoverningTokenType::Membership
+    );
+
+    assert_eq!(
+        realm_config_account.council_token_config.voter_weight_addin,
+        realm_setup_args
+            .council_token_config_args
+            .voter_weight_addin
+    );
+
+    assert_eq!(
+        realm_config_account
+            .council_token_config
+            .max_voter_weight_addin,
+        realm_setup_args
+            .council_token_config_args
+            .max_voter_weight_addin
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_without_existing_realm_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    governance_test.remove_realm_config_account(&realm_cookie.realm_config.address);
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_token_owner_record_lock_authorities() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let community_token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let council_token_owner_record_lock_authority_cookie = governance_test
+        .with_council_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        vec![community_token_owner_record_lock_authority_cookie
+            .authority
+            .pubkey()],
+        realm_config_account.community_token_config.lock_authorities
+    );
+
+    assert_eq!(
+        vec![council_token_owner_record_lock_authority_cookie
+            .authority
+            .pubkey()],
+        realm_config_account.council_token_config.lock_authorities
+    );
+}

--- a/governance/program/tests/process_set_realm_config_item_2022.rs
+++ b/governance/program/tests/process_set_realm_config_item_2022.rs
@@ -1,0 +1,386 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            realm::SetRealmConfigItemArgs,
+            realm_config::{GoverningTokenConfig, RealmConfigAccount},
+        },
+        tools::structs::{Reserved110, SetConfigItemActionType},
+    },
+    spl_governance_tools::account::AccountMaxSize,
+};
+
+#[tokio::test]
+async fn test_add_community_token_owner_record_lock_authority() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        1,
+        realm_config_account
+            .community_token_config
+            .lock_authorities
+            .len()
+    );
+
+    assert_eq!(
+        &token_owner_record_lock_authority_cookie.authority.pubkey(),
+        realm_config_account
+            .community_token_config
+            .lock_authorities
+            .first()
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_remove_community_token_owner_record_lock_authority() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Remove,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: token_owner_record_lock_authority_cookie.authority.pubkey(),
+    };
+
+    governance_test
+        .set_realm_config_item(&realm_cookie, args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        0,
+        realm_config_account
+            .community_token_config
+            .lock_authorities
+            .len()
+    );
+}
+
+#[tokio::test]
+async fn test_add_council_token_owner_record_lock_authority() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_council_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        1,
+        realm_config_account
+            .council_token_config
+            .lock_authorities
+            .len()
+    );
+
+    assert_eq!(
+        &token_owner_record_lock_authority_cookie.authority.pubkey(),
+        realm_config_account
+            .council_token_config
+            .lock_authorities
+            .first()
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_item_with_realm_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Add,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: Keypair::new().pubkey(),
+    };
+
+    // Act
+    let err = governance_test
+        .set_realm_config_item_using_ix(
+            &realm_cookie,
+            args,
+            |i| i.accounts[2].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_item_with_invalid_realm_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Add,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: Keypair::new().pubkey(),
+    };
+
+    let realm_authority = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .set_realm_config_item_using_ix(
+            &realm_cookie,
+            args,
+            |i| i.accounts[2].pubkey = realm_authority.pubkey(),
+            Some(&[&realm_authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidAuthorityForRealm.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_item_with_invalid_realm_config_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Add,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: Keypair::new().pubkey(),
+    };
+
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    // Act
+    let err = governance_test
+        .set_realm_config_item_using_ix(
+            &realm_cookie,
+            args,
+            |i| i.accounts[1].pubkey = realm_cookie2.realm_config.address,
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmConfigForRealm.into());
+}
+
+#[tokio::test]
+async fn test_add_token_owner_record_lock_authority_with_invalid_governing_token_mint() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Add,
+        governing_token_mint: Pubkey::new_unique(), // Use invalid mint
+        authority: Keypair::new().pubkey(),
+    };
+
+    // Act
+    let err = governance_test
+        .set_realm_config_item(&realm_cookie, args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGoverningTokenMint.into());
+}
+
+#[tokio::test]
+async fn test_add_token_owner_record_lock_authority_with_authority_already_exists_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Add,
+        governing_token_mint: realm_cookie.account.config.council_mint.unwrap(),
+        // Set the same authority
+        authority: Pubkey::new_unique(),
+    };
+
+    governance_test
+        .set_realm_config_item(&realm_cookie, args.clone())
+        .await
+        .unwrap();
+
+    // Advance the clock to accept the same transaction
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .set_realm_config_item(&realm_cookie, args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::TokenOwnerRecordLockAuthorityAlreadyExists.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_item_without_existing_realm_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    governance_test.remove_realm_config_account(&realm_cookie.realm_config.address);
+
+    // Act
+    governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(
+        1,
+        realm_config_account
+            .community_token_config
+            .lock_authorities
+            .len()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_item_with_extended_account_size() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_config_account = governance_test
+        .bench
+        .get_account(&realm_cookie.realm_config.address)
+        .await
+        .unwrap();
+
+    // RealmConfig without any lock authorities
+    let realm_config = RealmConfigAccount {
+        account_type: GovernanceAccountType::RealmConfig,
+        realm: realm_cookie.address,
+        community_token_config: GoverningTokenConfig::default(),
+        council_token_config: GoverningTokenConfig::default(),
+        reserved: Reserved110::default(),
+    };
+
+    assert_eq!(
+        realm_config.get_max_size().unwrap() + 32,
+        realm_config_account.data.len()
+    );
+}
+
+#[tokio::test]
+async fn test_remove_token_owner_record_lock_authority_with_authority_not_found_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let args = SetRealmConfigItemArgs::TokenOwnerRecordLockAuthority {
+        action: SetConfigItemActionType::Remove,
+        governing_token_mint: realm_cookie.account.community_mint,
+        authority: token_owner_record_lock_authority_cookie.authority.pubkey(),
+    };
+
+    governance_test
+        .set_realm_config_item(&realm_cookie, args.clone())
+        .await
+        .unwrap();
+
+    // Advance the clock to accept the same transaction
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .set_realm_config_item(&realm_cookie, args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::TokenOwnerRecordLockAuthorityNotFound.into()
+    );
+}

--- a/governance/program/tests/process_set_token_owner_record_lock_2022.rs
+++ b/governance/program/tests/process_set_token_owner_record_lock_2022.rs
@@ -1,0 +1,706 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::{
+        error::GovernanceError,
+        state::{enums::GovernanceAccountType, legacy::TokenOwnerRecordV1},
+    },
+    spl_governance_tools::account::AccountMaxSize,
+};
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record_account.locks.len());
+    assert_eq!(
+        token_owner_record_lock_cookie.authority,
+        token_owner_record_account.locks[0].authority
+    );
+    assert_eq!(
+        token_owner_record_lock_cookie.lock_id,
+        token_owner_record_account.locks[0].lock_id
+    );
+    assert_eq!(
+        token_owner_record_lock_cookie.expiry,
+        token_owner_record_account.locks[0].expiry
+    );
+}
+
+#[tokio::test]
+async fn test_override_existing_token_owner_record_lock() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    let expiry = None;
+    let lock_id = token_owner_record_lock_cookie.lock_id;
+
+    // Act
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record_account.locks.len());
+    assert_eq!(
+        token_owner_record_lock_authority_cookie.authority.pubkey(),
+        token_owner_record_account.locks[0].authority
+    );
+    assert_eq!(lock_id, token_owner_record_account.locks[0].lock_id);
+    assert_eq!(expiry, token_owner_record_account.locks[0].expiry);
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_and_trim_expired_lock() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_past_timestamp(token_owner_record_lock_cookie.expiry.unwrap())
+        .await;
+
+    let expiry = None;
+    let lock_id = 101;
+
+    // Act
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record_account.locks.len());
+    assert_eq!(
+        token_owner_record_lock_authority_cookie.authority.pubkey(),
+        token_owner_record_account.locks[0].authority
+    );
+    assert_eq!(lock_id, token_owner_record_account.locks[0].lock_id);
+    assert_eq!(expiry, token_owner_record_account.locks[0].expiry);
+}
+
+#[tokio::test]
+async fn test_set_multiple_token_owner_record_locks() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie1 = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie2 = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let token_owner_record_lock_cookie1 = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie1,
+        )
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_cookie2 = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie2,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(2, token_owner_record_account.locks.len());
+    assert_eq!(
+        token_owner_record_lock_cookie1.authority,
+        token_owner_record_account.locks[0].authority
+    );
+    assert_eq!(
+        token_owner_record_lock_cookie2.authority,
+        token_owner_record_account.locks[1].authority
+    );
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_lock_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let expiry = None;
+    let lock_id = 101;
+
+    // Act
+    let err = governance_test
+        .set_token_owner_record_lock_using_ix(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+            |i| i.accounts[3].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::TokenOwnerRecordLockAuthorityMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_invalid_lock_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let expiry = None;
+    let lock_id = 101;
+    let lock_authority = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .set_token_owner_record_lock_using_ix(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+            |i| i.accounts[3].pubkey = lock_authority.pubkey(),
+            Some(&[&lock_authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidTokenOwnerRecordLockAuthority.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_invalid_realm_config_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let expiry = None;
+    let lock_id = 101;
+
+    // Act
+    let err = governance_test
+        .set_token_owner_record_lock_using_ix(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+            |i| i.accounts[1].pubkey = realm_cookie2.realm_config.address,
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmConfigForRealm.into());
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_invalid_token_owner_record_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie2)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let expiry = None;
+    let lock_id = 101;
+
+    // Act
+    let err = governance_test
+        .set_token_owner_record_lock_using_ix(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+            |i| i.accounts[2].pubkey = token_owner_record_cookie2.address,
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmForTokenOwnerRecord.into());
+}
+
+#[tokio::test]
+async fn test_set_community_token_owner_record_lock_with_council_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let council_token_owner_record_lock_authority_cookie = governance_test
+        .with_council_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &council_token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidTokenOwnerRecordLockAuthority.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_community_token_owner_record_lock_with_expired_lock_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let expiry = Some(0);
+    let lock_id = 101;
+
+    // Act
+    let err = governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id,
+            expiry,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::ExpiredTokenOwnerRecordLock.into());
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_extended_account_size() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut token_owner_record_account = governance_test
+        .bench
+        .get_account(&token_owner_record_cookie.address)
+        .await
+        .unwrap();
+
+    let token_owner_record_account_size = token_owner_record_account.data.len();
+
+    // Act
+    governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    token_owner_record_account = governance_test
+        .bench
+        .get_account(&token_owner_record_cookie.address)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        token_owner_record_account_size + 42,
+        token_owner_record_account.data.len()
+    );
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_for_v1_account() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_data_v1 = TokenOwnerRecordV1 {
+        account_type: GovernanceAccountType::TokenOwnerRecordV1,
+        realm: token_owner_record_cookie.account.realm,
+        governing_token_mint: token_owner_record_cookie.account.governing_token_mint,
+        governing_token_owner: token_owner_record_cookie.account.governing_token_owner,
+        governing_token_deposit_amount: token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        governance_delegate: token_owner_record_cookie.account.governance_delegate,
+        unrelinquished_votes_count: token_owner_record_cookie.account.unrelinquished_votes_count,
+        outstanding_proposal_count: token_owner_record_cookie.account.outstanding_proposal_count,
+        version: 0,
+        reserved: [0; 6],
+    };
+
+    governance_test.bench.set_borsh_account(
+        &governance_test.program_id,
+        &token_owner_record_cookie.address,
+        &token_owner_record_data_v1,
+    );
+
+    // Act
+    governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_data = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(
+        GovernanceAccountType::TokenOwnerRecordV2,
+        token_owner_record_data.account_type
+    );
+
+    let token_owner_record_account = governance_test
+        .bench
+        .get_account(&token_owner_record_cookie.address)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        token_owner_record_data.get_max_size().unwrap(),
+        token_owner_record_account.data.len()
+    );
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_non_expiring_and_expiring_locks() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let lock_id1 = 0;
+    let expiry1 = None;
+
+    let lock_id2 = 1;
+    let clock = governance_test.bench.get_clock().await;
+    let expiry2 = Some(clock.unix_timestamp + 1);
+
+    // Act
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id1,
+            expiry1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id2,
+            expiry2,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(None, token_owner_record_account.locks[0].expiry);
+    assert_eq!(expiry2, token_owner_record_account.locks[1].expiry);
+}
+
+#[tokio::test]
+async fn test_set_token_owner_record_lock_with_multiple_non_expiring_locks() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    let lock_id1 = 0;
+    let expiry1 = None;
+
+    let lock_id2 = 1;
+    let expiry2 = None;
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id1,
+            expiry1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id2,
+            expiry2,
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+    let new_expiry1 = Some(clock.unix_timestamp + 1);
+
+    // Act
+
+    governance_test
+        .set_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+            lock_id1,
+            new_expiry1,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record_account = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(new_expiry1, token_owner_record_account.locks[0].expiry);
+    assert_eq!(None, token_owner_record_account.locks[1].expiry);
+}

--- a/governance/program/tests/process_sign_off_proposal_2022.rs
+++ b/governance/program/tests/process_sign_off_proposal_2022.rs
@@ -1,0 +1,919 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+
+use {
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+    spl_governance_tools::error::GovernanceToolsError,
+};
+
+#[tokio::test]
+async fn test_sign_off_proposal() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(1, proposal_account.signatories_count);
+    assert_eq!(1, proposal_account.signatories_signed_off_count);
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.signing_off_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.voting_at);
+    assert_eq!(Some(clock.slot), proposal_account.voting_at_slot);
+
+    let signatory_record_account = governance_test
+        .get_signatory_record_account(&signatory_record_cookie.address)
+        .await;
+
+    assert!(signatory_record_account.signed_off);
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_with_signatory_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .sign_off_proposal_using_instruction(
+            &proposal_cookie,
+            &signatory_record_cookie,
+            |i| i.accounts[3].is_signer = false, // signatory
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::SignatoryMustSign.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_by_owner() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.signatories_count);
+    assert_eq!(0, proposal_account.signatories_signed_off_count);
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.signing_off_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.voting_at);
+    assert_eq!(Some(clock.slot), proposal_account.voting_at_slot);
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_by_owner_with_owner_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .sign_off_proposal_by_owner_using_instruction(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            |i| i.accounts[3].is_signer = false, // signatory
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_by_owner_with_other_proposal_owner_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie2)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidProposalOwnerAccount.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_by_owner_with_existing_signatories_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidSignatoryAddress.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_with_non_existing_governance_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Override Governance with non existing account
+    proposal_cookie.account.governance = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_with_non_existing_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Override Realm with non existing account
+    proposal_cookie.realm = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_with_required_signatory() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory = Keypair::new();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    let new_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &new_proposal_cookie,
+            &signatory,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&new_proposal_cookie.address)
+        .await;
+
+    assert_eq!(1, proposal_account.signatories_signed_off_count);
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_partial_sign_off_proposal_with_two_governance_signatories() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory_1 = Keypair::new();
+    let signatory_2 = Keypair::new();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie_1 = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie_2 = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory_2.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie_1)
+        .await
+        .unwrap();
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie_2)
+        .await
+        .unwrap();
+
+    // End setup proposal
+
+    let new_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory_2.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &new_proposal_cookie,
+            &signatory_1,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&new_proposal_cookie.address)
+        .await;
+
+    assert_eq!(1, proposal_account.signatories_signed_off_count);
+    assert_eq!(ProposalState::SigningOff, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_repeat_sign_off_proposal_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory_1 = Keypair::new();
+    let signatory_2 = Keypair::new();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Proposal to create required signatory 1
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Proposal to create required signatory 2
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory_2.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &proposal_cookie,
+            &signatory_1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // End setup proposals
+
+    let new_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory_2.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    // Sign off 1
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &new_proposal_cookie,
+            &signatory_1,
+        )
+        .await
+        .unwrap();
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &new_proposal_cookie,
+            &signatory_1,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::SignatoryAlreadySignedOff.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_without_all_required_signatories_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let signatory_1 = Keypair::new();
+    let signatory_2 = Keypair::new();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Proposal to create required signatory 1
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // Proposal to create required signatory 2
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_add_required_signatory_transaction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_cookie,
+            &signatory_2.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &proposal_cookie,
+            &signatory_1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .unwrap();
+
+    // End setup proposals
+
+    let new_proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signatory_record_for_required_signatory(
+            &new_proposal_cookie,
+            &governance_cookie,
+            &signatory_1.pubkey(),
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .do_required_signoff(
+            &realm_cookie,
+            &governance_cookie,
+            &new_proposal_cookie,
+            &signatory_1,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::MissingRequiredSignatories.into());
+}

--- a/governance/program/tests/process_update_program_metadata_2022.rs
+++ b/governance/program/tests/process_update_program_metadata_2022.rs
@@ -1,0 +1,47 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+
+#[tokio::test]
+async fn test_update_program_metadata() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    // Act
+    let program_metadata_cookie = governance_test.with_program_metadata().await;
+
+    // Assert
+    let program_metadata_account = governance_test
+        .get_program_metadata_account(&program_metadata_cookie.address)
+        .await;
+
+    assert_eq!(program_metadata_cookie.account, program_metadata_account);
+}
+
+#[tokio::test]
+async fn test_update_existing_program_metadata() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let program_metadata_cookie1 = governance_test.with_program_metadata().await;
+
+    // Act
+    governance_test.advance_clock().await;
+
+    let program_metadata_cookie2 = governance_test.with_program_metadata().await;
+
+    // Assert
+    let program_metadata_account = governance_test
+        .get_program_metadata_account(&program_metadata_cookie2.address)
+        .await;
+
+    assert_eq!(program_metadata_cookie2.account, program_metadata_account);
+
+    assert!(
+        program_metadata_cookie2.account.updated_at > program_metadata_cookie1.account.updated_at
+    )
+}

--- a/governance/program/tests/process_withdraw_governing_tokens_2022.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens_2022.rs
@@ -1,0 +1,507 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_program_test::*,
+};
+
+mod program_test;
+
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_sdk::signature::Signer,
+    spl_governance::{
+        error::GovernanceError,
+        instruction::withdraw_governing_tokens,
+        state::{
+            realm_config::GoverningTokenType, token_owner_record::get_token_owner_record_address,
+        },
+    },
+};
+
+#[tokio::test]
+async fn test_withdraw_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.governing_token_deposit_amount);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
+
+    assert_eq!(0, holding_account.amount);
+
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount,
+        source_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_council_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.governing_token_deposit_amount);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.council_token_holding_account.unwrap())
+        .await;
+
+    assert_eq!(0, holding_account.amount);
+
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount,
+        source_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_community_tokens_with_owner_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let hacker_token_destination = Pubkey::new_unique();
+
+    let mut withdraw_ix = withdraw_governing_tokens(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &hacker_token_destination,
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &realm_cookie.account.community_mint,
+    );
+
+    withdraw_ix.accounts[3] =
+        AccountMeta::new_readonly(token_owner_record_cookie.token_owner.pubkey(), false);
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[withdraw_ix], None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::GoverningTokenOwnerMustSign.into());
+}
+
+#[tokio::test]
+async fn test_withdraw_community_tokens_with_token_owner_record_address_mismatch_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let vote_record_address = get_token_owner_record_address(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &realm_cookie.account.community_mint,
+        &token_owner_record_cookie.token_owner.pubkey(),
+    );
+
+    let hacker_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut withdraw_ix = withdraw_governing_tokens(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &hacker_record_cookie.token_source,
+        &hacker_record_cookie.token_owner.pubkey(),
+        &realm_cookie.account.community_mint,
+    );
+
+    withdraw_ix.accounts[4] = AccountMeta::new(vote_record_address, false);
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(&[withdraw_ix], Some(&[&hacker_record_cookie.token_owner]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidTokenOwnerRecordAccountAddress.into()
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_with_unrelinquished_votes_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::AllVotesMustBeRelinquishedToWithdrawGoverningTokens.into()
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_after_relinquishing_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount,
+        source_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_tokens_with_malicious_holding_account_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to maliciously withdraw from other token account owned by realm
+
+    let realm_token_account_cookie = governance_test
+        .bench
+        .with_token_account(
+            &realm_cookie.account.community_mint,
+            &realm_cookie.address,
+            &realm_cookie.community_mint_authority,
+            200,
+        )
+        .await;
+
+    let mut withdraw_ix = withdraw_governing_tokens(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &token_owner_record_cookie.token_source,
+        &token_owner_record_cookie.token_owner.pubkey(),
+        &realm_cookie.account.community_mint,
+    );
+
+    withdraw_ix.accounts[1].pubkey = realm_token_account_cookie.address;
+
+    // Act
+    let err = governance_test
+        .bench
+        .process_transaction(
+            &[withdraw_ix],
+            Some(&[&token_owner_record_cookie.token_owner]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningTokenHoldingAccount.into()
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_with_outstanding_proposals_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::AllProposalsMustBeFinalisedToWithdrawGoverningTokens.into()
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_after_proposal_cancelled() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .cancel_proposal(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount,
+        source_account.amount
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_council_tokens_with_cannot_withdraw_membership_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .withdraw_council_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::CannotWithdrawMembershipTokens.into());
+}
+
+#[tokio::test]
+async fn test_withdraw_dormant_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args.community_token_config_args.token_type = GoverningTokenType::Dormant;
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.governing_token_deposit_amount);
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_with_token_owner_record_lock_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_lock_authority_cookie = governance_test
+        .with_community_token_owner_record_lock_authority(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_token_owner_record_lock(
+            &token_owner_record_cookie,
+            &token_owner_record_lock_authority_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::TokenOwnerRecordLocked.into());
+}

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -116,33 +116,51 @@ pub struct GovernanceProgramTest {
     pub program_id: Pubkey,
     pub voter_weight_addin_id: Option<Pubkey>,
     pub max_voter_weight_addin_id: Option<Pubkey>,
+    pub token_program_id:Pubkey
 }
 
 impl GovernanceProgramTest {
     #[allow(dead_code)]
+    pub async fn start_new_with_token_2022() -> Self {
+        Self::start_impl(false, false,true).await
+    }
+    #[allow(dead_code)]
     pub async fn start_new() -> Self {
-        Self::start_impl(false, false).await
+        Self::start_impl(false, false,false).await
     }
 
+    #[allow(dead_code)]
+    pub async fn start_with_voter_weight_addin_with_token_2022() -> Self {
+        Self::start_with_addin_mock(true, false,true).await
+    }
     #[allow(dead_code)]
     pub async fn start_with_voter_weight_addin() -> Self {
-        Self::start_with_addin_mock(true, false).await
+        Self::start_with_addin_mock(true, false,false).await
     }
 
+    #[allow(dead_code)]
+    pub async fn start_with_max_voter_weight_addin_with_token_2022() -> Self {
+        Self::start_with_addin_mock(false, true,true).await
+    }
     #[allow(dead_code)]
     pub async fn start_with_max_voter_weight_addin() -> Self {
-        Self::start_with_addin_mock(false, true).await
+        Self::start_with_addin_mock(false, true,false).await
     }
 
     #[allow(dead_code)]
+    pub async fn start_with_all_addins_with_token_2022() -> Self {
+        Self::start_with_addin_mock(true, true,true).await
+    }
+    #[allow(dead_code)]
     pub async fn start_with_all_addins() -> Self {
-        Self::start_with_addin_mock(true, true).await
+        Self::start_with_addin_mock(true, true,false).await
     }
 
     #[allow(dead_code)]
     pub async fn start_with_addin_mock(
         use_voter_weight_addin: bool,
         use_max_voter_weight_addin: bool,
+        with_token_2022:bool
     ) -> Self {
         // We only ensure the addin mock program is built but it doesn't detect
         // changes.
@@ -153,13 +171,22 @@ impl GovernanceProgramTest {
         // executed from the script.
         ensure_addin_mock_is_built();
 
-        Self::start_impl(use_voter_weight_addin, use_max_voter_weight_addin).await
+        Self::start_impl(use_voter_weight_addin, use_max_voter_weight_addin,with_token_2022).await
     }
 
     #[allow(dead_code)]
-    async fn start_impl(use_voter_weight_addin: bool, use_max_voter_weight_addin: bool) -> Self {
+    async fn start_impl(use_voter_weight_addin: bool, use_max_voter_weight_addin: bool,with_token_2022:bool) -> Self {
         let mut program_test = ProgramTest::default();
-
+        // //Default that it is normal token
+        // let mut token_program_id = Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+        // if with_token_2022 {
+        //     token_program_id = Pubkey::from_str("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+        // }
+         //Default that it is normal token
+         let mut token_program_id = spl_token::id();
+         if with_token_2022 {
+             token_program_id = spl_token_2022::id();
+         }
         let program_id = Pubkey::from_str("Governance111111111111111111111111111111111").unwrap();
         program_test.add_program(
             "spl_governance",
@@ -195,6 +222,7 @@ impl GovernanceProgramTest {
             program_id,
             voter_weight_addin_id,
             max_voter_weight_addin_id,
+            token_program_id
         }
     }
 
@@ -262,6 +290,7 @@ impl GovernanceProgramTest {
                 &community_token_mint_keypair,
                 &community_token_mint_authority.pubkey(),
                 None,
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -284,6 +313,7 @@ impl GovernanceProgramTest {
                     &council_token_mint_keypair,
                     &council_token_mint_authority.pubkey(),
                     None,
+                    Some(&self.token_program_id)
                 )
                 .await;
 
@@ -337,6 +367,7 @@ impl GovernanceProgramTest {
             realm_setup_args
                 .community_mint_max_voter_weight_source
                 .clone(),
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -442,6 +473,7 @@ impl GovernanceProgramTest {
             name.clone(),
             min_community_weight_to_create_governance,
             community_mint_max_voter_weight_source,
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -779,6 +811,7 @@ impl GovernanceProgramTest {
                 amount,
                 &token_owner,
                 &transfer_authority.pubkey(),
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -791,6 +824,7 @@ impl GovernanceProgramTest {
             &self.bench.payer.pubkey(),
             amount,
             governing_mint,
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -856,6 +890,7 @@ impl GovernanceProgramTest {
             &self.bench.payer.pubkey(),
             amount,
             governing_mint,
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -912,6 +947,7 @@ impl GovernanceProgramTest {
                 &token_account_keypair,
                 &realm_cookie.account.community_mint,
                 &self.bench.payer.pubkey(),
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -921,6 +957,7 @@ impl GovernanceProgramTest {
                 &realm_cookie.community_mint_authority,
                 &token_account_keypair.pubkey(),
                 amount,
+                Some(&self.token_program_id)
             )
             .await;
     }
@@ -935,6 +972,7 @@ impl GovernanceProgramTest {
                 &token_account_keypair,
                 &council_mint,
                 &self.bench.payer.pubkey(),
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -944,6 +982,7 @@ impl GovernanceProgramTest {
                 realm_cookie.council_mint_authority.as_ref().unwrap(),
                 &token_account_keypair.pubkey(),
                 amount,
+                Some(&self.token_program_id)
             )
             .await;
     }
@@ -975,6 +1014,7 @@ impl GovernanceProgramTest {
             &self.bench.payer.pubkey(),
             amount,
             governing_token_mint,
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -1269,6 +1309,7 @@ impl GovernanceProgramTest {
             &token_owner_record_cookie.token_source,
             &governing_token_owner.pubkey(),
             governing_token_mint,
+            Some(&self.token_program_id)
         );
 
         self.bench
@@ -1338,6 +1379,7 @@ impl GovernanceProgramTest {
             governing_token_mint,
             &revoke_authority.pubkey(),
             amount,
+            Some(&self.token_program_id)
         );
 
         instruction_override(&mut revoke_governing_tokens_ix);
@@ -1358,7 +1400,10 @@ impl GovernanceProgramTest {
         let mint_keypair = Keypair::new();
 
         self.bench
-            .create_mint(&mint_keypair, &governance_cookie.address, None)
+            .create_mint(&mint_keypair, 
+                &governance_cookie.address,
+                 None,
+                 Some(&self.token_program_id))
             .await;
 
         GovernedMintCookie {
@@ -1376,7 +1421,10 @@ impl GovernanceProgramTest {
         let mint_authority = Keypair::new();
 
         self.bench
-            .create_mint(&mint_keypair, &mint_authority.pubkey(), None)
+            .create_mint(&mint_keypair, 
+                &mint_authority.pubkey(),
+                 None,
+                 Some(&self.token_program_id))
             .await;
 
         let token_account_keypair = Keypair::new();
@@ -1387,6 +1435,7 @@ impl GovernanceProgramTest {
                 &token_account_keypair,
                 &mint_keypair.pubkey(),
                 &token_account_owner,
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -1396,6 +1445,7 @@ impl GovernanceProgramTest {
                 &mint_authority,
                 &token_account_keypair.pubkey(),
                 100,
+                Some(&self.token_program_id)
             )
             .await;
 
@@ -2233,11 +2283,12 @@ impl GovernanceProgramTest {
                 &token_account_keypair,
                 &governed_mint_cookie.address,
                 &self.bench.payer.pubkey(),
+                Some(&self.token_program_id)
             )
             .await;
 
         let mut instruction = spl_token::instruction::mint_to(
-            &spl_token::id(),
+            &token_program_id,
             &governed_mint_cookie.address,
             &token_account_keypair.pubkey(),
             &proposal_cookie.account.governance,
@@ -2270,11 +2321,12 @@ impl GovernanceProgramTest {
                 &token_account_keypair,
                 &governed_token_account_cookie.token_mint,
                 &self.bench.payer.pubkey(),
+                Some(&self.token_program_id)
             )
             .await;
 
         let mut instruction = spl_token::instruction::transfer(
-            &spl_token::id(),
+            &self.token_program_id,
             &governed_token_account_cookie.address,
             &token_account_keypair.pubkey(),
             &proposal_cookie.account.governance,

--- a/governance/program/tests/setup_realm_with_all_addins_2022.rs
+++ b/governance/program/tests/setup_realm_with_all_addins_2022.rs
@@ -1,0 +1,279 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
+
+mod program_test;
+
+use {crate::program_test::args::RealmSetupArgs, program_test::*};
+
+#[tokio::test]
+async fn test_create_realm_with_all_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    // Act
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_all_addins_for_realm_without_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_all_addin_for_realm_without_council_and_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_all_realm_addins_for_realm_with_all_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    let max_community_voter_weight_addin_address = Pubkey::new_unique();
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
+
+    let community_voter_weight_addin_address = Pubkey::new_unique();
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = Some(community_voter_weight_addin_address);
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+    assert_eq!(
+        realm_config_data
+            .community_token_config
+            .max_voter_weight_addin,
+        Some(max_community_voter_weight_addin_address)
+    );
+    assert_eq!(
+        realm_config_data.community_token_config.voter_weight_addin,
+        Some(community_voter_weight_addin_address)
+    );
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_without_addins_for_realm_without_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = None;
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = None;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
+}

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin_2022.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin_2022.rs
@@ -1,0 +1,224 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
+
+mod program_test;
+
+use {crate::program_test::args::RealmSetupArgs, program_test::*};
+
+#[tokio::test]
+async fn test_create_realm_with_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    // Act
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
+    let max_community_voter_weight_addin_address = Pubkey::new_unique();
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+    assert_eq!(
+        realm_config_data
+            .community_token_config
+            .max_voter_weight_addin,
+        Some(max_community_voter_weight_addin_address)
+    );
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .max_voter_weight_addin = None;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_existing_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
+}

--- a/governance/program/tests/setup_realm_with_voter_weight_addin_2022.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin_2022.rs
@@ -1,0 +1,226 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
+
+mod program_test;
+
+use {crate::program_test::args::RealmSetupArgs, program_test::*};
+
+#[tokio::test]
+async fn test_create_realm_with_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    // Act
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = None;
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    let community_voter_weight_addin_address = Pubkey::new_unique();
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = Some(community_voter_weight_addin_address);
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
+    assert_eq!(
+        realm_config_data.community_token_config.voter_weight_addin,
+        Some(community_voter_weight_addin_address)
+    );
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addins() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = None;
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    realm_setup_args
+        .community_token_config_args
+        .voter_weight_addin = None;
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existing_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let realm_setup_args = RealmSetupArgs::default();
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let realm_config_data = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
+}

--- a/governance/program/tests/use_proposals_with_multiple_options_2022.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options_2022.rs
@@ -1,0 +1,1743 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use {
+    program_test::*,
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::{ProposalState, VoteThreshold},
+            proposal::{MultiChoiceType, OptionVoteResult, VoteType},
+            vote_record::{Vote, VoteChoice},
+        },
+    },
+};
+
+#[tokio::test]
+async fn test_create_proposal_with_single_choice_options_and_deny_option() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let options = vec!["option 1".to_string(), "option 2".to_string()];
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            options,
+            true,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.vote_type, VoteType::SingleChoice);
+    assert!(proposal_account.deny_vote_weight.is_some());
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_multiple_choice_options_and_without_deny_option() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let options = vec!["option 1".to_string(), "option 2".to_string()];
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            options,
+            false,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::FullWeight,
+                min_voter_options: 1,
+                max_winning_options: 2,
+                max_voter_options: 2,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        proposal_account.vote_type,
+        VoteType::MultiChoice {
+            choice_type: MultiChoiceType::FullWeight,
+            min_voter_options: 1,
+            max_winning_options: 2,
+            max_voter_options: 2,
+        }
+    );
+    assert!(proposal_account.deny_vote_weight.is_none());
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+}
+
+#[tokio::test]
+async fn test_insert_transaction_with_proposal_not_executable_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            false,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::ProposalIsNotExecutable.into());
+}
+
+#[tokio::test]
+async fn test_insert_transactions_for_multiple_options() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            true,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    // option 1 / transaction 0
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 1, Some(0))
+        .await
+        .unwrap();
+
+    // option 1 / transaction 1
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 1, Some(1))
+        .await
+        .unwrap();
+
+    // option 1 / transaction 2
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 1, Some(2))
+        .await
+        .unwrap();
+
+    // option 0 / transaction 0
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(0))
+        .await
+        .unwrap();
+
+    // option 0 / transaction 1
+    governance_test
+        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(1))
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(2, proposal_account.options[0].transactions_count);
+    assert_eq!(3, proposal_account.options[1].transactions_count);
+}
+
+#[tokio::test]
+async fn test_vote_on_none_executable_single_choice_proposal_with_multiple_options() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            false,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    // Advance timestamp past voting_base_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[1].vote_result
+    );
+
+    // None executable proposal transitions to Completed when vote is finalized
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_options() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            false,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::FullWeight,
+                min_voter_options: 1,
+                max_winning_options: 3,
+                max_voter_options: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    // Advance timestamp past voting_base_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[1].vote_result
+    );
+
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[2].vote_result
+    );
+
+    // None executable proposal transitions to Completed when vote is finalized
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_success() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokes approval quorum
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            true,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::FullWeight,
+                min_voter_options: 1,
+                max_winning_options: 3,
+                max_voter_options: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie1,
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    // choice 1: 200
+    // choice 2: 100
+    // choice 3: 0
+    // deny: 100
+    // yes threshold: 100
+
+    let vote1 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .await
+        .unwrap();
+
+    let vote2 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
+        .await
+        .unwrap();
+
+    // Advance timestamp past voting_base_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(200, proposal_account.options[0].vote_weight);
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+
+    assert_eq!(100, proposal_account.options[1].vote_weight);
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[1].vote_result
+    );
+
+    assert_eq!(0, proposal_account.options[2].vote_weight);
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[2].vote_result
+    );
+}
+
+#[tokio::test]
+async fn test_execute_proposal_with_multiple_options_and_partial_success() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokes approval quorum
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            true,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::FullWeight,
+                min_voter_options: 1,
+                max_winning_options: 3,
+                max_voter_options: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie3 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            2,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    // deny: 100
+    // choice 1: 100 -> Defeated
+    // choice 2: 200 -> Success
+    // choice 3: 0 -> Defeated
+    // yes threshold: 100
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
+        .await
+        .unwrap();
+
+    let vote1 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .await
+        .unwrap();
+
+    let vote2 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .await
+        .unwrap();
+
+    // Advance timestamp past voting_base_time
+    governance_test
+        .advance_clock_by_min_timespan(governance_cookie.account.config.voting_base_time as u64)
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let mut proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    // Act
+
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .err()
+        .unwrap();
+
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .unwrap();
+
+    let transaction3_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie3)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+
+    assert_eq!(
+        transaction3_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokes approval quorum
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            true,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::FullWeight,
+                min_voter_options: 1,
+                max_winning_options: 3,
+                max_voter_options: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie3 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            2,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(
+            &proposal_cookie,
+            &governance_cookie,
+            &token_owner_record_cookie1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Deny)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Deny)
+        .await
+        .unwrap();
+
+    // Advance timestamp past voting_base_time
+    governance_test
+        .advance_clock_by_min_timespan(governance_cookie.account.config.voting_base_time as u64)
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    // Act
+
+    let mut err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+
+    // Act
+
+    err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+
+    // Act
+
+    err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie3)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_10_options_and_cast_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let options_count = 10;
+
+    let options: Vec<String> = (0..options_count)
+        .map(|n| format!("option {:?}", n))
+        .collect();
+
+    let options_len = options.len() as u8;
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            options,
+            false,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::FullWeight,
+                min_voter_options: 1,
+                max_winning_options: options_len,
+                max_voter_options: options_len,
+            },
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(
+        (0..options_count)
+            .map(|_| VoteChoice {
+                rank: 0,
+                weight_percentage: 100,
+            })
+            .collect(),
+    );
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        proposal_account.vote_type,
+        VoteType::MultiChoice {
+            choice_type: MultiChoiceType::FullWeight,
+            min_voter_options: 1,
+            max_winning_options: options_len,
+            max_voter_options: options_len,
+        }
+    );
+    assert!(proposal_account.deny_vote_weight.is_none());
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_non_executable() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+                "option 4".to_string(),
+            ],
+            false,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
+                max_winning_options: 4,
+                max_voter_options: 4,
+            },
+        )
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 30,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 29,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 41,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[1].vote_result
+    );
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[2].vote_result
+    );
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[3].vote_result
+    );
+    assert_eq!(
+        (token_owner_record_cookie.token_source_amount as f32 * 0.3) as u64,
+        proposal_account.options[0].vote_weight
+    );
+    assert_eq!(
+        (token_owner_record_cookie.token_source_amount as f32 * 0.29) as u64,
+        proposal_account.options[1].vote_weight
+    );
+    assert_eq!(
+        (token_owner_record_cookie.token_source_amount as f32 * 0.41) as u64,
+        proposal_account.options[2].vote_weight
+    );
+    assert_eq!(0_u64, proposal_account.options[3].vote_weight);
+
+    // None executable proposal transitions to Completed when vote is finalized
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 tokens each, sum 300 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 60 tokes approval quorum as 20% of 300 is 60
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(20);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+                "option 4".to_string(),
+            ],
+            true,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
+                max_winning_options: 4,
+                max_voter_options: 4,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie3 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            2,
+            Some(0),
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie4 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            3,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    // vote1:
+    //   deny: 100
+    // vote2 + vote3:
+    //   choice 1: 0 -> Defeated
+    //   choice 2: 91 -> Defeated (91 is over 60, 20% from 300, but deny overrules)
+    //   choice 3: 101 -> Success
+    //   choice 4: 8 -> Defeated (below of 60)
+
+    let vote1 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 30,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 70,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    let vote2 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 61,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 31,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 8,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
+        .await
+        .expect("Casting deny vote of owner 3 should succeed");
+
+    let clock = governance_test.bench.get_clock().await;
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let mut proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    // Act
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .expect_err("Choice 1 should fail to execute, it hasn't got enough votes");
+    let transaction2_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .expect_err("Choice 2 should fail to execute, it hasn't got enough votes");
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie3)
+        .await
+        .expect("Choice 3 should be executed as it won the poll");
+    let transaction4_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie4)
+        .await
+        .expect_err("Choice 4 should be executed as the winner has been executed already");
+
+    // Assert
+    proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+    assert_eq!(
+        transaction2_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+    assert_eq!(
+        transaction4_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 tokens each, sum 300 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 60 tokes approval quorum as 30% of 200 is 60
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            true,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
+                max_winning_options: 3,
+                max_voter_options: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie3 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            2,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    // vote1 + vote2:
+    //   choice 1: 28 -> Defeated (below 60)
+    //   choice 2: 105 -> Success
+    //   choice 3: 61 -> Success
+
+    let vote1 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 14,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 55,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 31,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    let vote2 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 20,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 50,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 30,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    // Advance timestamp past voting_base_time
+    let clock = governance_test.bench.get_clock().await;
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let mut proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    // Act
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .expect_err("Choice 1 should fail to execute, it hasn't got enough votes");
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .expect("Choice 2 should be executed as it passed the poll");
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie3)
+        .await
+        .expect("Choice 3 should be executed as it passed the poll");
+
+    // Assert
+    proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022()().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // 100 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(3);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let governed_mint_cookie = governance_test.with_governed_mint(&governance_cookie).await;
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            true,
+            VoteType::MultiChoice {
+                choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
+                max_winning_options: 2,
+                max_voter_options: 2,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Deny)
+        .await
+        .expect("Casting deny vote for owner 1 should succeed");
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Deny)
+        .await
+        .expect("Casting deny vote for owner 1 should succeed");
+
+    // Advance timestamp past voting_base_time
+    let clock = governance_test.bench.get_clock().await;
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.voting_base_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
+        .await;
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    // Act
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .expect_err("The proposal was denied, error on choice 1 execution expected");
+    let transaction2_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .expect_err("The proposal was denied, error on choice 2 execution expected");
+
+    // Assert
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+    assert_eq!(
+        transaction2_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}

--- a/governance/program/tests/use_realm_with_all_addins_2022.rs
+++ b/governance/program/tests/use_realm_with_all_addins_2022.rs
@@ -1,0 +1,247 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use {
+    program_test::{args::*, *},
+    spl_governance::state::enums::ProposalState,
+};
+
+#[tokio::test]
+async fn test_cast_community_vote_with_all_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    // voter weight 120
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // max voter weight 250
+    governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 250, None)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(120, vote_record_account.voter_weight);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting)
+}
+
+#[tokio::test]
+async fn test_cast_council_vote_with_all_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_owner_record(&realm_cookie)
+        .await;
+
+    // voter weight 120
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // max voter weight 250
+    governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 250, None)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(120, vote_record_account.voter_weight);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting)
+}
+
+#[tokio::test]
+async fn test_tip_vote_with_all_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    // voter weight 120
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // max voter weight 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(120, vote_record_account.voter_weight);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Defeated)
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_all_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    // voter weight 120
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // max voter weight 400
+    let max_voter_weight_record_cookie = governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 400, None)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .await
+        .unwrap();
+
+    governance_test
+        .advance_clock_past_voting_time(&governance_cookie)
+        .await;
+
+    // Act
+
+    governance_test
+        .finalize_vote(
+            &realm_cookie,
+            &proposal_cookie,
+            Some(max_voter_weight_record_cookie),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(120, vote_record_account.voter_weight);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Defeated)
+}

--- a/governance/program/tests/use_realm_with_max_voter_weight_addin_2022.rs
+++ b/governance/program/tests/use_realm_with_max_voter_weight_addin_2022.rs
@@ -1,0 +1,378 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use {
+    program_test::{args::*, *},
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+};
+
+#[tokio::test]
+async fn test_cast_vote_with_community_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting)
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_council_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COUNCIL_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting)
+}
+
+#[tokio::test]
+async fn test_tip_vote_with_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 180
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit_amount(&realm_cookie, 180)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    assert_eq!(proposal_account.max_vote_weight, Some(200));
+}
+
+#[tokio::test]
+async fn test_tip_vote_with_max_voter_weight_addin_and_max_below_total_cast_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Downgrade MaxVoterWeight to 50
+    governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 50, None)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    // Adjusted max based on cast votes
+    assert_eq!(proposal_account.max_vote_weight, Some(100));
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Lower max to 120
+    let max_voter_weight_record_cookie = governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 120, None)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_voting_time(&governance_cookie)
+        .await;
+
+    // Act
+
+    governance_test
+        .finalize_vote(
+            &realm_cookie,
+            &proposal_cookie,
+            Some(max_voter_weight_record_cookie),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    assert_eq!(proposal_account.max_vote_weight, Some(120));
+}
+
+#[tokio::test]
+async fn test_finalize_vote_with_max_voter_weight_addin_and_max_below_total_cast_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Lower max to 50 while 100 already cast
+    let max_voter_weight_record_cookie = governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 50, None)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_voting_time(&governance_cookie)
+        .await;
+
+    // Act
+
+    governance_test
+        .finalize_vote(
+            &realm_cookie,
+            &proposal_cookie,
+            Some(max_voter_weight_record_cookie),
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    // Adjusted max based on cast votes
+    assert_eq!(proposal_account.max_vote_weight, Some(100));
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_max_voter_weight_addin_and_expired_record_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 200, Some(1))
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::MaxVoterWeightRecordExpired.into());
+}

--- a/governance/program/tests/use_realm_with_voter_weight_addin_2022.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin_2022.rs
@@ -1,0 +1,482 @@
+#![cfg(feature = "test-sbf")]
+
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
+
+mod program_test;
+
+use {
+    program_test::{args::*, *},
+    spl_governance::{
+        error::GovernanceError,
+        state::vote_record::{Vote, VoteChoice},
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
+};
+
+#[tokio::test]
+async fn test_create_governance_with_community_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}
+
+#[tokio::test]
+async fn test_create_governance_with_council_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COUNCIL_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(120, vote_record_account.voter_weight);
+    assert_eq!(
+        Vote::Approve(vec![VoteChoice {
+            rank: 0,
+            weight_percentage: 100
+        }]),
+        vote_record_account.vote
+    );
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(120, proposal_account.options[0].vote_weight);
+}
+
+#[tokio::test]
+async fn test_create_token_governance_with_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let token_governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, token_governance_account);
+}
+
+#[tokio::test]
+async fn test_create_governance_with_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}
+
+#[tokio::test]
+async fn test_create_governance_with_voter_weight_action_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(
+            &mut token_owner_record_cookie,
+            100,
+            None,
+            Some(VoterWeightAction::CastVote), // Use wrong action
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    //  Assert
+    assert_eq!(err, GovernanceError::VoterWeightRecordInvalidAction.into());
+}
+
+#[tokio::test]
+async fn test_create_governance_with_voter_weight_expiry_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(
+            &mut token_owner_record_cookie,
+            100,
+            Some(1), // Past slot
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    //  Assert
+    assert_eq!(err, GovernanceError::VoterWeightRecordExpired.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_voter_weight_action_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 100, None, None, None)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(
+            &mut token_owner_record_cookie,
+            100,
+            None,
+            Some(VoterWeightAction::CreateGovernance), // Use wrong action
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    //  Assert
+    assert_eq!(err, GovernanceError::VoterWeightRecordInvalidAction.into());
+}
+
+#[tokio::test]
+async fn test_create_governance_with_voter_weight_action_target_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(
+            &mut token_owner_record_cookie,
+            100,
+            None,
+            None,
+            Some(Pubkey::new_unique()), // Invalid target
+        )
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    //  Assert
+    assert_eq!(
+        err,
+        GovernanceError::VoterWeightRecordInvalidActionTarget.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_voter_weight_action_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(
+            &mut token_owner_record_cookie,
+            100,
+            None,
+            Some(VoterWeightAction::CreateGovernance),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    //  Assert
+    assert_eq!(err, GovernanceError::VoterWeightRecordInvalidAction.into());
+}
+
+#[tokio::test]
+async fn test_create_governance_with_voter_weight_record() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin_with_token_2022().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test.advance_clock().await;
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .with_voter_weight_addin_record_impl(
+            &mut token_owner_record_cookie,
+            100,
+            Some(clock.slot),
+            Some(VoterWeightAction::CreateGovernance),
+            Some(realm_cookie.address),
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}

--- a/governance/program/tests/use_veto_vote_2022.rs
+++ b/governance/program/tests/use_veto_vote_2022.rs
@@ -1,0 +1,965 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    crate::program_test::args::{PluginSetupArgs, RealmSetupArgs},
+    program_test::*,
+    solana_program::instruction::AccountMeta,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::{ProposalState, VoteThreshold},
+            vote_record::Vote,
+        },
+    },
+    spl_governance_test_sdk::tools::clone_keypair,
+};
+
+#[tokio::test]
+async fn test_cast_council_veto_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 120
+    governance_test.mint_council_tokens(&realm_cookie, 20).await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.veto_vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+    assert_eq!(
+        proposal_account.voting_completed_at,
+        Some(clock.unix_timestamp)
+    );
+
+    assert_eq!(Some(120), proposal_account.max_vote_weight);
+    assert_eq!(
+        Some(governance_cookie.account.config.council_veto_vote_threshold),
+        proposal_account.vote_threshold
+    );
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record.unrelinquished_votes_count);
+}
+
+#[tokio::test]
+async fn test_cast_community_veto_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra community tokens for total supply of 120
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.veto_vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+
+    assert_eq!(Some(120), proposal_account.max_vote_weight);
+    assert_eq!(
+        Some(
+            governance_cookie
+                .account
+                .config
+                .community_veto_vote_threshold
+        ),
+        proposal_account.vote_threshold
+    );
+}
+
+#[tokio::test]
+async fn test_cast_community_veto_vote_with_community_veto_disabled_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_veto_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenMintNotAllowedToVote.into()
+    );
+}
+
+#[tokio::test]
+async fn test_cast_veto_vote_with_invalid_voting_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    // Try to use Council Veto on Council vote Proposal
+    let err = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGoverningMintForProposal.into());
+}
+
+#[tokio::test]
+async fn test_cast_veto_vote_with_council_veto_vote_disabled_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.council_veto_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::GoverningTokenMintNotAllowedToVote.into()
+    );
+}
+
+#[tokio::test]
+async fn test_cast_veto_vote_without_tipping() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 201 to prevent tipping
+    governance_test
+        .mint_council_tokens(&realm_cookie, 101)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.veto_vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Voting);
+}
+
+#[tokio::test]
+async fn test_cast_multiple_veto_votes_for_partially_approved_proposal() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 210 to prevent single vote
+    // tipping
+    governance_test.mint_council_tokens(&realm_cookie, 10).await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 200 to prevent single vote
+    // tipping
+    governance_test
+        .mint_community_tokens(&realm_cookie, 100)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Partially approve Proposal
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &proposal_owner_record_cookie,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Partially Veto Proposal
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Act
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(200, proposal_account.veto_vote_weight);
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+}
+
+#[tokio::test]
+async fn test_cast_veto_vote_with_no_council_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.council_veto_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Remove Council
+    let realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGoverningTokenMint.into());
+}
+
+#[tokio::test]
+async fn test_relinquish_veto_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 201 to prevent tipping
+    governance_test
+        .mint_council_tokens(&realm_cookie, 101)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+    // Act
+
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.veto_vote_weight);
+
+    assert_eq!(proposal_account.state, ProposalState::Voting);
+}
+
+#[tokio::test]
+async fn test_relinquish_veto_vote_with_vote_record_for_different_voting_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 210
+    governance_test
+        .mint_council_tokens(&realm_cookie, 110)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &council_token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &council_token_owner_record_cookie,
+            Vote::Veto,
+        )
+        .await
+        .unwrap();
+
+    // Create Community TokenOwnerRecord for council_token_owner and Cast Community
+    // vote
+    let community_token_owner_record_cookie = governance_test
+        .with_community_token_deposit_by_owner(
+            &realm_cookie,
+            100,
+            clone_keypair(&council_token_owner_record_cookie.token_owner),
+        )
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 250
+    governance_test
+        .mint_community_tokens(&realm_cookie, 150)
+        .await;
+
+    let community_vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &community_token_owner_record_cookie,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .relinquish_vote_using_instruction(
+            &proposal_cookie,
+            &council_token_owner_record_cookie,
+            |i| {
+                // Try to use a vote_record from community Yes vote to relinquish council Veto
+                // vote
+                i.accounts[4] = AccountMeta::new(community_vote_record_cookie.address, false)
+            },
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::InvalidGoverningMintForProposal.into());
+}
+
+#[tokio::test]
+async fn test_cast_veto_vote_with_council_only_allowed_to_veto() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Allow Council to cast only Veto votes
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.council_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+}
+
+#[tokio::test]
+async fn test_cast_yes_and_veto_votes_with_yes_as_winning_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 210 to prevent single vote
+    // tipping
+    governance_test
+        .mint_council_tokens(&realm_cookie, 110)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Partially Veto Proposal
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Act
+
+    // Approve Proposal
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &proposal_owner_record_cookie,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(100, proposal_account.veto_vote_weight);
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+}
+
+#[tokio::test]
+async fn test_veto_vote_with_community_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Create Proposal for Council vote
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+}
+
+#[tokio::test]
+async fn test_veto_vote_with_community_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_veto_vote_threshold = VoteThreshold::YesVotePercentage(50); // 50% Veto
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Create Proposal for Council vote
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+}
+
+#[tokio::test]
+async fn test_veto_vote_with_community_max_voter_weight_addin_and_veto_not_tipped() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_veto_vote_threshold = VoteThreshold::YesVotePercentage(51); // 51% Veto
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    // Create Proposal for Council vote
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting);
+}
+
+#[tokio::test]
+async fn test_cast_council_veto_vote_within_cool_off_time() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new_with_token_2022().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 120
+    governance_test.mint_council_tokens(&realm_cookie, 20).await;
+
+    // Set none default voting cool off time
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.voting_cool_off_time = 50;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Advance timestamp into voting_cool_off_time
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .advance_clock_past_timestamp(
+            clock.unix_timestamp + governance_cookie.account.config.voting_base_time as i64,
+        )
+        .await;
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+}

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -123,19 +123,26 @@ impl ProgramTestBench {
         mint_keypair: &Keypair,
         mint_authority: &Pubkey,
         freeze_authority: Option<&Pubkey>,
+        token_program_id:Option<&Pubkey>
     ) {
         let mint_rent = self.rent.minimum_balance(spl_token::state::Mint::LEN);
-
+        //Determine if token_program_id is provided else set it to normal token program
+        let normal_spl_token = &spl_token::id();
+        let token_program = if token_program_id.is_some() {
+           token_program_id.unwrap()
+        }else{
+            normal_spl_token
+        };
         let instructions = [
             system_instruction::create_account(
                 &self.context.payer.pubkey(),
                 &mint_keypair.pubkey(),
                 mint_rent,
                 spl_token::state::Mint::LEN as u64,
-                &spl_token::id(),
+                token_program,
             ),
             spl_token::instruction::initialize_mint(
-                &spl_token::id(),
+                token_program,
                 &mint_keypair.pubkey(),
                 mint_authority,
                 freeze_authority,
@@ -156,9 +163,17 @@ impl ProgramTestBench {
         account_authority: &Keypair,
         new_authority: Option<&Pubkey>,
         authority_type: AuthorityType,
+        token_program_id:Option<&Pubkey>
     ) {
+          //Determine if token_program_id is provided else set it to normal token program
+          let normal_spl_token = &spl_token::id();
+          let token_program = if token_program_id.is_some() {
+             token_program_id.unwrap()
+          }else{
+              normal_spl_token
+          };
         let set_authority_ix = set_authority(
-            &spl_token::id(),
+            token_program,
             account,
             new_authority,
             authority_type,
@@ -178,18 +193,26 @@ impl ProgramTestBench {
         token_account_keypair: &Keypair,
         token_mint: &Pubkey,
         owner: &Pubkey,
+        token_program_id:Option<&Pubkey>
     ) {
+          //Determine if token_program_id is provided else set it to normal token program
+          let normal_spl_token = &spl_token::id();
+          let token_program = if token_program_id.is_some() {
+             token_program_id.unwrap()
+          }else{
+              normal_spl_token
+          };
         let create_account_instruction = system_instruction::create_account(
             &self.context.payer.pubkey(),
             &token_account_keypair.pubkey(),
             self.rent
                 .minimum_balance(spl_token::state::Account::get_packed_len()),
             spl_token::state::Account::get_packed_len() as u64,
-            &spl_token::id(),
+            token_program,
         );
 
         let initialize_account_instruction = spl_token::instruction::initialize_account(
-            &spl_token::id(),
+            token_program,
             &token_account_keypair.pubkey(),
             token_mint,
             owner,
@@ -211,10 +234,18 @@ impl ProgramTestBench {
         owner: &Pubkey,
         token_mint_authority: &Keypair,
         amount: u64,
+        token_program_id:Option<&Pubkey>
     ) -> TokenAccountCookie {
+    //Determine if token_program_id is provided else set it to normal token program
+    let normal_spl_token = &spl_token::id();
+    let token_program = if token_program_id.is_some() {
+        token_program_id.unwrap()
+    }else{
+        normal_spl_token
+    };
         let token_account_keypair = Keypair::new();
 
-        self.create_empty_token_account(&token_account_keypair, token_mint, owner)
+        self.create_empty_token_account(&token_account_keypair, token_mint, owner,Some(token_program))
             .await;
 
         self.mint_tokens(
@@ -222,6 +253,7 @@ impl ProgramTestBench {
             token_mint_authority,
             &token_account_keypair.pubkey(),
             amount,
+            Some(token_program)
         )
         .await;
 
@@ -244,9 +276,17 @@ impl ProgramTestBench {
         token_mint_authority: &Keypair,
         token_account: &Pubkey,
         amount: u64,
+        token_program_id:Option<&Pubkey>
     ) {
+          //Determine if token_program_id is provided else set it to normal token program
+          let normal_spl_token = &spl_token::id();
+          let token_program = if token_program_id.is_some() {
+             token_program_id.unwrap()
+          }else{
+              normal_spl_token
+          };
         let mint_instruction = spl_token::instruction::mint_to(
-            &spl_token::id(),
+            token_program,
             token_mint,
             token_account,
             &token_mint_authority.pubkey(),
@@ -269,18 +309,26 @@ impl ProgramTestBench {
         amount: u64,
         owner: &Keypair,
         transfer_authority: &Pubkey,
+        token_program_id:Option<&Pubkey>
     ) {
+          //Determine if token_program_id is provided else set it to normal token program
+          let normal_spl_token = &spl_token::id();
+          let token_program = if token_program_id.is_some() {
+             token_program_id.unwrap()
+          }else{
+              normal_spl_token
+          };
         let create_account_instruction = system_instruction::create_account(
             &self.context.payer.pubkey(),
             &token_account_keypair.pubkey(),
             self.rent
                 .minimum_balance(spl_token::state::Account::get_packed_len()),
             spl_token::state::Account::get_packed_len() as u64,
-            &spl_token::id(),
+            token_program,
         );
 
         let initialize_account_instruction = spl_token::instruction::initialize_account(
-            &spl_token::id(),
+            token_program,
             &token_account_keypair.pubkey(),
             token_mint,
             &owner.pubkey(),
@@ -288,7 +336,7 @@ impl ProgramTestBench {
         .unwrap();
 
         let mint_instruction = spl_token::instruction::mint_to(
-            &spl_token::id(),
+            token_program,
             token_mint,
             &token_account_keypair.pubkey(),
             &token_mint_authority.pubkey(),
@@ -298,7 +346,7 @@ impl ProgramTestBench {
         .unwrap();
 
         let approve_instruction = spl_token::instruction::approve(
-            &spl_token::id(),
+            token_program,
             &token_account_keypair.pubkey(),
             transfer_authority,
             &owner.pubkey(),


### PR DESCRIPTION
This update contains various upgrade to the governance to support token2022, all tests are also duplicated for the token 2022 support, the test sdk is also updated to support token 2022.

If there is any issue while testing, kindly respond with a message. Looking forward to successful merge of this pull request. Thanks